### PR TITLE
Fix for converting a pull request id to a branch name. 

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValueRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValueRepository.java
@@ -1,5 +1,6 @@
 package stashpullrequestbuilder.stashpullrequestbuilder.stash;
 
+import org.apache.commons.lang.StringUtils;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.codehaus.jackson.annotate.JsonProperty;
@@ -9,6 +10,8 @@ import org.codehaus.jackson.annotate.JsonProperty;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StashPullRequestResponseValueRepository {
+    private static final String REFS_PREFIX = "refs/";
+    private static final String HEADS_PREFIX = "heads/";
     private StashPullRequestResponseValueRepositoryRepository repository;
 
     @JsonIgnore
@@ -27,13 +30,40 @@ public class StashPullRequestResponseValueRepository {
     }
 
     @JsonProperty("id")
-    public void setId(String id) { //TODO
+    public void setId(String id) {
         this.id = id;
         this.branch = new StashPullRequestResponseValueRepositoryBranch();
-        String[] ref = id.split("/");
-        if (ref.length > 0) {
-            this.branch.setName(ref[ref.length - 1]);
+        this.branch.setName( convertIdToBranchName(id) );
+    }
+
+    /**
+     * Convert a pull request identifier to a branch name. Assumption: A pull request identifier always looks like
+     * "refs/heads/master". The branch name is without the "refs/heads/" part.
+     * To be on the save side, this method will check for the "refs/" and the "heads/" and strip them accordingly.
+     *
+     * More information about the Stash REST API can be found here:
+     * <a href="https://developer.atlassian.com/stash/docs/latest/">https://developer.atlassian.com/stash/docs/latest/</a>
+     *
+     * @param id The unique name of the pull request.
+     * @return The branch name
+     */
+    private String convertIdToBranchName(String id) {
+        String branchName = StringUtils.EMPTY;
+        if(StringUtils.isEmpty(id)){
+            return branchName;
         }
+
+        branchName = id;
+
+        if(StringUtils.startsWith(branchName, REFS_PREFIX)){
+            branchName = StringUtils.removeStart(branchName, REFS_PREFIX);
+        }
+
+        if(StringUtils.startsWith(branchName, HEADS_PREFIX)){
+            branchName = StringUtils.removeStart(branchName, HEADS_PREFIX);
+        }
+
+        return branchName;
     }
 
     @JsonProperty("latestChangeset")

--- a/src/main/test/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValueRepositoryTest.java
+++ b/src/main/test/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValueRepositoryTest.java
@@ -1,0 +1,68 @@
+package stashpullrequestbuilder.stashpullrequestbuilder.stash;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static junit.framework.Assert.assertEquals;
+
+/**
+ * Test for checking the logic inside the StashPullRequestResponseValueRepository class.
+ * Since most of this class consists of getters/setters only one method gets tested.
+ *
+ * @author bart
+ */
+public class StashPullRequestResponseValueRepositoryTest {
+
+    StashPullRequestResponseValueRepository stashPullRequestResponseValueRepository;
+
+    @Before
+    public void setUp() throws Exception {
+        stashPullRequestResponseValueRepository =
+                new StashPullRequestResponseValueRepository();
+    }
+
+    @Test
+    public void testSetIdWithNullValue() throws Exception {
+        // Test on null values
+        stashPullRequestResponseValueRepository.setId(null);
+        String branchName = stashPullRequestResponseValueRepository.getBranch().getName();
+        assertEquals("", branchName);
+    }
+
+    @Test
+    public void testSetIdWithEmptyValue() throws Exception {
+        // Test on empty String
+        stashPullRequestResponseValueRepository.setId("");
+        String branchName = stashPullRequestResponseValueRepository.getBranch().getName();
+        assertEquals("", branchName);
+    }
+
+    @Test
+    public void testSetIdWithSlashInBranchName() throws Exception {
+
+        // Test if the branch name get extracted the right way. Allowing for '/' in the branch name
+        stashPullRequestResponseValueRepository.setId("refs/heads/release/1.0.0");
+        String branchNameWithSlash= stashPullRequestResponseValueRepository.getBranch().getName();
+        assertEquals("release/1.0.0", branchNameWithSlash);
+    }
+
+    @Test
+    public void testSetIdWithNormalBranchName() throws Exception {
+
+        // Normal case, a branch name without '/' characters
+        stashPullRequestResponseValueRepository.setId("refs/heads/master");
+        String branchNameWithoutSlash = stashPullRequestResponseValueRepository.getBranch().getName();
+        assertEquals("master", branchNameWithoutSlash);
+
+    }
+
+    @Test
+    public void testSetIdWithUnexpectedBranchName() throws Exception {
+
+        // Normal case, but now with a weird pull request identifier
+        stashPullRequestResponseValueRepository.setId("refs/weird/master");
+        String branchNameWithoutSlash = stashPullRequestResponseValueRepository.getBranch().getName();
+        assertEquals("weird/master", branchNameWithoutSlash);
+
+    }
+}


### PR DESCRIPTION
Fix for converting a pull request id to a valid branch name. The branch name now will also support '/' in the branch names, which is a pattern widely used. This means the following pull request gets converted:
refs/heads/release/1.0.0 -> release/1.0.0
refs/heads/master -> master
refs/weird/master -> weird/master
