### PR TITLE
Work on only the newest pull requests on the list

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
@@ -41,7 +41,7 @@ public class StashApiClient {
     }
 
     public List<StashPullRequestResponseValue> getPullRequests() {
-        String response = getRequest(pullRequestsPath());
+        String response = getRequest(pullRequestsPath() + "?order=NEWEST");
         try {
             return parsePullRequestJson(response).getPrValues();
         } catch(Exception e) {


### PR DESCRIPTION
Since Stash only lists the oldest 25 pull requests, and the rest are paginated, it's better to order by the newest ones since those will need to be tested more frequently than stale, old, pull requests. 

This PR changes the order from oldest to newest to newest to oldest and thus works on the 25 newest pull requests
