### PR TITLE
Make objectmapper a static final

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
@@ -25,6 +25,7 @@ import java.util.logging.Logger;
  */
 public class StashApiClient {
     private static final Logger logger = Logger.getLogger(StashApiClient.class.getName());
+    private static final ObjectMapper mapper = new ObjectMapper();
 
     private String apiBaseUrl ;
 
@@ -168,7 +169,6 @@ public class StashApiClient {
         client.getState().setCredentials(AuthScope.ANY, credentials);
         PostMethod httppost = new PostMethod(path);
 
-        ObjectMapper mapper = new ObjectMapper();
         ObjectNode node = mapper.getNodeFactory().objectNode();
         node.put("text", comment);
 
@@ -200,14 +200,12 @@ public class StashApiClient {
     }
 
     private StashPullRequestResponse parsePullRequestJson(String response) throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         StashPullRequestResponse parsedResponse;
         parsedResponse = mapper.readValue(response, StashPullRequestResponse.class);
         return parsedResponse;
     }
 
     private StashPullRequestActivityResponse parseCommentJson(String response) throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         StashPullRequestActivityResponse parsedResponse;
         parsedResponse = mapper.readValue(response, StashPullRequestActivityResponse.class);
         return parsedResponse;
@@ -224,7 +222,6 @@ public class StashApiClient {
     }
 
     private StashPullRequestComment parseSingleCommentJson(String response) throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         StashPullRequestComment parsedResponse;
         parsedResponse = mapper.readValue(
                 response,
@@ -233,7 +230,6 @@ public class StashApiClient {
     }
 
     protected static StashPullRequestMergableResponse parsePullRequestMergeStatus(String response) throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         StashPullRequestMergableResponse parsedResponse;
         parsedResponse = mapper.readValue(
                 response,


### PR DESCRIPTION
Make ObjectMappers a static final so we can cache this object, they are thread safe and meant to be cached. This will also improve the speed at which this Plugin parses json code. 
