### PR TITLE
Add 'sourceCommitHash' parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ You may want Jenkins to attempt to merge your PR before doing the build -- this 
 If you are merging into your target branch, you might want Jenkins to do a new build of the Pull Request when the target branch changes.
 - There is a checkbox that says, "Rebuild if destination branch changes?" which enables this check.
 
+##Notify Stash Instance (StashNotifier plugin)
+
+If you have enabled the 'Notify Stash Instance' Post-build Action and also enabled 'Merge before build', you need to set '${sourceCommitHash}' as Commit SHA-1.  This will record the build result against the source commit.
 
 ##Rerun test builds
 

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -145,6 +145,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         values.put("destinationRepositoryOwner", new StringParameterValue("destinationRepositoryOwner", cause.getDestinationRepositoryOwner()));
         values.put("destinationRepositoryName", new StringParameterValue("destinationRepositoryName", cause.getDestinationRepositoryName()));
         values.put("pullRequestTitle", new StringParameterValue("pullRequestTitle", cause.getPullRequestTitle()));
+        values.put("sourceCommitHash", new StringParameterValue("sourceCommitHash", cause.getSourceCommitHash()));
         return this.job.scheduleBuild2(0, cause, new ParametersAction(new ArrayList(values.values())));
     }
 


### PR DESCRIPTION
This is useful for integration with the 'StashNotifier' plugin, when performing a 'Merge Before Building'.
Without the sourceCommitHash, the build result is reported against a non-existent commit ID in Stash.

Addresses https://github.com/nemccarthy/stash-pullrequest-builder-plugin/issues/37.
