### PR TITLE
Jenkins 30558

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
@@ -9,7 +9,9 @@ import org.apache.commons.httpclient.methods.DeleteMethod;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.httpclient.methods.StringRequestEntity;
+import org.apache.commons.httpclient.params.HttpParams;
 import org.apache.commons.io.IOUtils;
+import org.apache.http.params.CoreConnectionPNames;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.node.ObjectNode;
 
@@ -20,6 +22,11 @@ import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -27,6 +34,11 @@ import java.util.logging.Logger;
  * Created by Nathan McCarthy
  */
 public class StashApiClient {
+	
+	private static final int HTTP_REQUEST_TIMEOUT_SECONDS = 30;
+	private static final int HTTP_CONNECTION_TIMEOUT_SECONDS = 10;
+	private static final int HTTP_SOCKET_TIMEOUT_SECONDS = 10;
+		
     private static final Logger logger = Logger.getLogger(StashApiClient.class.getName());
     private static final ObjectMapper mapper = new ObjectMapper();
 
@@ -115,6 +127,10 @@ public class StashApiClient {
 
     private HttpClient getHttpClient() {
         HttpClient client = new HttpClient();
+    	HttpParams httpParams = client.getParams();    	
+    	httpParams.setParameter(CoreConnectionPNames.CONNECTION_TIMEOUT, StashApiClient.HTTP_CONNECTION_TIMEOUT_SECONDS * 1000);
+    	httpParams.setParameter(CoreConnectionPNames.SO_TIMEOUT, StashApiClient.HTTP_SOCKET_TIMEOUT_SECONDS * 1000);
+        
 //        if (Jenkins.getInstance() != null) {
 //            ProxyConfiguration proxy = Jenkins.getInstance().proxy;
 //            if (proxy != null) {
@@ -138,19 +154,59 @@ public class StashApiClient {
         HttpClient client = getHttpClient();
         client.getState().setCredentials(AuthScope.ANY, credentials);
         GetMethod httpget = new GetMethod(path);
+        httpget.setRequestHeader("Connection", "close");
         client.getParams().setAuthenticationPreemptive(true);
         String response = null;
+        FutureTask<String> httpTask = null;
+        Thread thread;
         try {
-            client.executeMethod(httpget);
-            InputStream responseBodyAsStream = httpget.getResponseBodyAsStream();
-            StringWriter stringWriter = new StringWriter();
-            IOUtils.copy(responseBodyAsStream, stringWriter, "UTF-8");
-            response = stringWriter.toString();
-        } catch (HttpException e) {
+            httpTask = new FutureTask<String>(new Callable<String>() {
+
+            	private HttpClient client;
+            	private GetMethod httpget;
+            	
+                @Override
+                public String call() throws Exception {
+            		String response = null;
+                	try {
+                        client.executeMethod(httpget);
+                        InputStream responseBodyAsStream = httpget.getResponseBodyAsStream();
+                        StringWriter stringWriter = new StringWriter();
+                        IOUtils.copy(responseBodyAsStream, stringWriter, "UTF-8");
+                        response = stringWriter.toString();
+                    } catch (HttpException e) {
+                        e.printStackTrace();
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                	
+                	return response;
+
+                }
+                
+                public Callable<String> init(HttpClient client, GetMethod httpget) {
+                	this.client = client;
+                	this.httpget = httpget;
+                	return this;
+                }
+                
+              }.init(client, httpget));
+            thread = new Thread(httpTask);
+            thread.start();
+            response = httpTask.get((long)StashApiClient.HTTP_REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            
+        } catch (InterruptedException e) {
             e.printStackTrace();
-        } catch (IOException e) {
+        } catch (ExecutionException e) {
             e.printStackTrace();
+        } catch (TimeoutException e) {
+            e.printStackTrace();
+            httpget.abort();
+            httpTask.cancel(true);
+        } finally {
+        	httpget.releaseConnection();
         }
+            
         logger.log(Level.FINEST, "PR-GET-RESPONSE:" + response);
         return response;
     }
@@ -159,13 +215,54 @@ public class StashApiClient {
         HttpClient client = getHttpClient();
         client.getState().setCredentials(AuthScope.ANY, credentials);
         DeleteMethod httppost = new DeleteMethod(path);
+        httppost.setRequestHeader("Connection", "close");
         client.getParams().setAuthenticationPreemptive(true);
         int res = -1;
+        FutureTask<Integer> httpTask = null;
+        Thread thread;
+
         try {
-            res = client.executeMethod(httppost);
-        } catch (IOException e) {
+            httpTask = new FutureTask<Integer>(new Callable<Integer>() {
+
+            	private HttpClient client;
+            	private DeleteMethod httppost;
+            	
+                @Override
+                public Integer call() throws Exception {
+                	int res = -1;
+                    try {
+                        res = client.executeMethod(httppost);
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                    
+                    return res;
+
+                }
+                
+                public Callable<Integer> init(HttpClient client, DeleteMethod httppost) {
+                	this.client = client;
+                	this.httppost = httppost;
+                	return this;
+                }
+                
+              }.init(client, httppost));
+            thread = new Thread(httpTask);
+            thread.start();
+            res = httpTask.get((long)StashApiClient.HTTP_REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            
+        } catch (InterruptedException e) {
             e.printStackTrace();
+        } catch (ExecutionException e) {
+            e.printStackTrace();
+        } catch (TimeoutException e) {
+            e.printStackTrace();
+            httppost.abort();
+            httpTask.cancel(true);
+        } finally {
+        	httppost.releaseConnection();
         }
+        
         logger.log(Level.FINE, "Delete comment {" + path + "} returned result code; " + res);
     }
 
@@ -174,6 +271,7 @@ public class StashApiClient {
         HttpClient client = getHttpClient();
         client.getState().setCredentials(AuthScope.ANY, credentials);
         PostMethod httppost = new PostMethod(path);
+        httppost.setRequestHeader("Connection", "close");
 
         ObjectNode node = mapper.getNodeFactory().objectNode();
         node.put("text", comment);
@@ -191,20 +289,62 @@ public class StashApiClient {
         httppost.setRequestEntity(requestEntity);
         client.getParams().setAuthenticationPreemptive(true);
         String response = "";
+        FutureTask<String> httpTask = null;
+        Thread thread;
+
         try {
-            client.executeMethod(httppost);
-            InputStream responseBodyAsStream = httppost.getResponseBodyAsStream();
-            StringWriter stringWriter = new StringWriter();
-            IOUtils.copy(responseBodyAsStream, stringWriter, "UTF-8");
-            response = stringWriter.toString();
-            logger.info("API Request Response: " + response);
-        } catch (HttpException e) {
+            httpTask = new FutureTask<String>(new Callable<String>() {
+
+            	private HttpClient client;
+            	private PostMethod httppost;
+            	
+                @Override
+                public String call() throws Exception {
+                	String response = "";
+                	
+                    try {
+                        client.executeMethod(httppost);
+                        InputStream responseBodyAsStream = httppost.getResponseBodyAsStream();
+                        StringWriter stringWriter = new StringWriter();
+                        IOUtils.copy(responseBodyAsStream, stringWriter, "UTF-8");
+                        response = stringWriter.toString();
+                        logger.info("API Request Response: " + response);
+                    } catch (HttpException e) {
+                        e.printStackTrace();
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                    
+                    return response;
+
+                }
+                
+                public Callable<String> init(HttpClient client, PostMethod httppost) {
+                	this.client = client;
+                	this.httppost = httppost;
+                	return this;
+                }
+                
+              }.init(client, httppost));
+            thread = new Thread(httpTask);
+            thread.start();
+            response = httpTask.get((long)StashApiClient.HTTP_REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            
+        } catch (InterruptedException e) {
             e.printStackTrace();
-        } catch (IOException e) {
+        } catch (ExecutionException e) {
             e.printStackTrace();
+        } catch (TimeoutException e) {
+            e.printStackTrace();
+            httppost.abort();
+            httpTask.cancel(true);            
+        } finally {
+        	httppost.releaseConnection();
         }
+                
         logger.log(Level.FINEST, "PR-POST-RESPONSE:" + response);
         return response;
+        
 
     }
 


### PR DESCRIPTION
I still haven’t gotten into the heart of the Jenkins Core code but apparently 1 bad plug-in, as pretty obvious the below debugs, can have a detrimental impact on the system if it hangs within its own timer task code.  Using jstack on the Jenkins process; I found the hang happens deep at native socket code causing the Stash Trigger to never complete.  Thread dump looks like this:

```
Thread 23311: (state = IN_NATIVE)
 - java.net.SocketInputStream.socketRead0(java.io.FileDescriptor, byte[], int, int, int) @bci=0 (Compiled frame; information may be imprecise)
 - java.net.SocketInputStream.read(byte[], int, int, int) @bci=87, line=152 (Compiled frame)
 - java.net.SocketInputStream.read(byte[], int, int) @bci=11, line=122 (Compiled frame)
 - sun.security.ssl.InputRecord.readFully(java.io.InputStream, byte[], int, int) @bci=21, line=442 (Compiled frame)
 - sun.security.ssl.InputRecord.read(java.io.InputStream, java.io.OutputStream) @bci=32, line=480 (Compiled frame)
 - sun.security.ssl.SSLSocketImpl.readRecord(sun.security.ssl.InputRecord, boolean) @bci=44, line=934 (Compiled frame)
 - sun.security.ssl.SSLSocketImpl.readDataRecord(sun.security.ssl.InputRecord) @bci=15, line=891 (Compiled frame)
 - sun.security.ssl.AppInputStream.read(byte[], int, int) @bci=72, line=102 (Compiled frame)
 - java.io.BufferedInputStream.fill() @bci=175, line=235 (Interpreted frame)
 - java.io.BufferedInputStream.read() @bci=12, line=254 (Compiled frame)
 - org.apache.commons.httpclient.HttpParser.readRawLine(java.io.InputStream) @bci=19, line=78 (Compiled frame)
 - org.apache.commons.httpclient.HttpParser.readLine(java.io.InputStream, java.lang.String) @bci=11, line=106 (Interpreted frame)
 - org.apache.commons.httpclient.HttpConnection.readLine(java.lang.String) @bci=19, line=1116 (Interpreted frame)
 - org.apache.commons.httpclient.HttpMethodBase.readStatusLine(org.apache.commons.httpclient.HttpState, org.apache.commons.httpclient.HttpConnection) @bci=36, line=1973 (Interpreted frame)
 - org.apache.commons.httpclient.HttpMethodBase.readResponse(org.apache.commons.httpclient.HttpState, org.apache.commons.httpclient.HttpConnection) @bci=21, line=1735 (Compiled frame)
 - org.apache.commons.httpclient.HttpMethodBase.execute(org.apache.commons.httpclient.HttpState, org.apache.commons.httpclient.HttpConnection) @bci=68, line=1098 (Interpreted frame)
 - org.apache.commons.httpclient.HttpMethodDirector.executeWithRetry(org.apache.commons.httpclient.HttpMethod) @bci=135, line=398 (Interpreted frame)
 - org.apache.commons.httpclient.HttpMethodDirector.executeMethod(org.apache.commons.httpclient.HttpMethod) @bci=288, line=171 (Interpreted frame)
 - org.apache.commons.httpclient.HttpClient.executeMethod(org.apache.commons.httpclient.HostConfiguration, org.apache.commons.httpclient.HttpMethod, org.apache.commons.httpclient.HttpState) @bci=114, line=397 (Interpreted frame)
 - org.apache.commons.httpclient.HttpClient.executeMethod(org.apache.commons.httpclient.HttpMethod) @bci=14, line=323 (Interpreted frame)
 - stashpullrequestbuilder.stashpullrequestbuilder.stash.StashApiClient.getRequest(java.lang.String) @bci=69, line=140 (Interpreted frame)
```

On the last hang-up I was able to kill the open socket and boom.. all cron jobs were back in business:

```
[root@triad-jenkins ~]# lsof -p 23220 | grep TCP | grep stash
java    23220 jenkins  894u  IPv6           40628689      0t0      TCP triad-jenkins.cisco.com:60443->rtp-apl-stash1.cisco.com:https (ESTABLISHED)
echo -e "call close(894)\nquit" > gdb_commands
gdb -p 23220 --batch -x gdb_commands
```

After analyzing the code for the stash pull request builder I found some areas where some defensive code could be added to possibly prevent some of these problems:
1.  For the HttpClient set two parameters:
   a.  ConnectionTimeout : This denotes the time elapsed before the connection established or Server responded to connection request.
   b.  SoTimeout : Maximum period inactivity between two consecutive data packets arriving at client side after connection is established.
2.  Related to item 1; apparently these two settings may not always work properly in some conditions in accordance to this bug filed against the jdk, https://bugs.openjdk.java.net/browse/JDK-8049846.  Thus for further defense; I added each api call to a FutureTask and start the task in a new thread with a limit time of 30 seconds.  After 30 seconds; a concurrent Timeout exception is thrown allowing the parent thread to abort the task and the http request.
3.  Eliminate the zombie sockets of this plugin using rfc 2616 14.10

This modification has been running on our production Jenkins server for 3 days now with no ill seen effects.  The big improvement was stability and a substatinal improvement in redunction of close_wait sockets server/client side.
