### PR TITLE
Support for all Jenkins build outcomes

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
@@ -69,7 +69,7 @@ public class StashBuilds {
         }
         String duration = build.getDurationString();
         repository.postFinishedComment(cause.getPullRequestId(), cause.getSourceCommitHash(),
-                cause.getDestinationCommitHash(), result == Result.SUCCESS, buildUrl,
+                cause.getDestinationCommitHash(), result, buildUrl,
                 build.getNumber(), additionalComment, duration);
     }
 }


### PR DESCRIPTION
The plugin supports only _successful_ and _failed_ build messages. We needed the posted messages to differentiate truly failed builds vs unstable ones (because of compiler warnings, or whatever)

This commit adds support for other types of build outcomes from Jenkins and provides an appropriate build message in the post-finish comment.
