### PR TITLE
[JENKINS-37468] Only offer valid credentials in the credentials drop down

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
       <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>credentials</artifactId>
-          <version>1.22</version>
+          <version>2.1.5</version>
       </dependency>
   </dependencies>
 


### PR DESCRIPTION
See [JENKINS-37468](https://issues.jenkins-ci.org/browse/JENKINS-37468)

I feel that the RFE is currently technically impossible as the REST API for query of the pull requests does not provide any support for SSH based authentication.

As such the RFE should probably be rejected.

Behind the RFE however, there is a valid bug. Namely that the drop down of credentials was including all Username based credentials (which would include SSH keys) yet only UsernamePassword credentials were being used.

This PR fixes the drop-down population to be restricted to Username Password credentials only.

Additionally this PR tidies up some of the usage of credentials (esp with respect to the interactions with the authorize-project plugin) and switches to the more modern APIs for populating drop-down boxes.

@reviewbybees @jenkinsci/code-reviewers
