### PR TITLE
Add support for Jenkins Pipeline.

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildListener.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildListener.java
@@ -1,7 +1,7 @@
 package stashpullrequestbuilder.stashpullrequestbuilder;
 
 import hudson.Extension;
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
 
@@ -12,25 +12,25 @@ import java.util.logging.Logger;
  * Created by Nathan McCarthy
  */
 @Extension
-public class StashBuildListener extends RunListener<AbstractBuild> {
+public class StashBuildListener extends RunListener<Run<?, ?>> {
     private static final Logger logger = Logger.getLogger(StashBuildTrigger.class.getName());
 
     @Override
-    public void onStarted(AbstractBuild abstractBuild, TaskListener listener) {
+    public void onStarted(Run<?, ?> run, TaskListener listener) {
         logger.info("BuildListener onStarted called.");
-        StashBuildTrigger trigger = StashBuildTrigger.getTrigger(abstractBuild.getProject());
+        StashBuildTrigger trigger = StashBuildTrigger.getTrigger(run.getParent());
         if (trigger == null) {
             return;
         }
-        trigger.getBuilder().getBuilds().onStarted(abstractBuild);
+        trigger.getBuilder().getBuilds().onStarted(run);
     }
 
     @Override
-    public void onCompleted(AbstractBuild abstractBuild, @Nonnull TaskListener listener) {
-        StashBuildTrigger trigger = StashBuildTrigger.getTrigger(abstractBuild.getProject());
+    public void onCompleted(Run<?, ?> run, @Nonnull TaskListener listener) {
+        StashBuildTrigger trigger = StashBuildTrigger.getTrigger(run.getParent());
         if (trigger == null) {
             return;
         }
-        trigger.getBuilder().getBuilds().onCompleted(abstractBuild, listener);
+        trigger.getBuilder().getBuilds().onCompleted(run, listener);
     }
 }

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPostBuildComment.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPostBuildComment.java
@@ -18,6 +18,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+// TODO: Make available in Jenkins Pipeline
 public class StashPostBuildComment extends Notifier {
     private static final Logger logger = Logger.getLogger(StashBuildTrigger.class.getName());
     private String buildSuccessfulComment;

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPullRequestsBuilder.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPullRequestsBuilder.java
@@ -2,8 +2,8 @@ package stashpullrequestbuilder.stashpullrequestbuilder;
 
 import static java.lang.String.format;
 
+import hudson.model.Job;
 import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashPullRequestResponseValue;
-import hudson.model.AbstractProject;
 
 import java.util.Collection;
 import java.util.logging.Logger;
@@ -13,7 +13,7 @@ import java.util.logging.Logger;
  */
 public class StashPullRequestsBuilder {
     private static final Logger logger = Logger.getLogger(StashBuildTrigger.class.getName());
-    private AbstractProject<?, ?> project;
+    private Job<?, ?> job;
     private StashBuildTrigger trigger;
     private StashRepository repository;
     private StashBuilds builds;
@@ -27,14 +27,14 @@ public class StashPullRequestsBuilder {
     }
 
     public void run() {
-        logger.info(format("Build Start (%s).", project.getName()));
+        logger.info(format("Build Start (%s).", job.getName()));
         this.repository.init();
         Collection<StashPullRequestResponseValue> targetPullRequests = this.repository.getTargetPullRequests();
         this.repository.addFutureBuildTasks(targetPullRequests);
     }
 
     public StashPullRequestsBuilder setupBuilder() {
-        if (this.project == null || this.trigger == null) {
+        if (this.job == null || this.trigger == null) {
             throw new IllegalStateException();
         }
         this.repository = new StashRepository(this.trigger.getProjectPath(), this);
@@ -42,16 +42,16 @@ public class StashPullRequestsBuilder {
         return this;
     }
 
-    public void setProject(AbstractProject<?, ?> project) {
-        this.project = project;
+    public void setJob(Job<?, ?> job) {
+        this.job = job;
     }
 
     public void setTrigger(StashBuildTrigger trigger) {
         this.trigger = trigger;
     }
 
-    public AbstractProject<?, ?> getProject() {
-        return this.project;
+    public Job<?, ?> getJob() {
+        return this.job;
     }
 
     public StashBuildTrigger getTrigger() {

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -68,7 +68,7 @@ public class StashRepository {
     }
 
     public Collection<StashPullRequestResponseValue> getTargetPullRequests() {
-        logger.info(format("Fetch PullRequests (%s).", builder.getProject().getName()));
+        logger.info(format("Fetch PullRequests (%s).", builder.getJob().getName()));
         List<StashPullRequestResponseValue> pullRequests = client.getPullRequests();
         List<StashPullRequestResponseValue> targetPullRequests = new ArrayList<StashPullRequestResponseValue>();
         for(StashPullRequestResponseValue pullRequest : pullRequests) {
@@ -80,11 +80,11 @@ public class StashRepository {
     }
 
     public String postBuildStartCommentTo(StashPullRequestResponseValue pullRequest) {
-            String sourceCommit = pullRequest.getFromRef().getLatestCommit();
-            String destinationCommit = pullRequest.getToRef().getLatestCommit();
-            String comment = format(BUILD_START_MARKER, builder.getProject().getDisplayName(), sourceCommit, destinationCommit);
-            StashPullRequestComment commentResponse = this.client.postPullRequestComment(pullRequest.getId(), comment);
-            return commentResponse.getCommentId().toString();
+        String sourceCommit = pullRequest.getFromRef().getLatestCommit();
+        String destinationCommit = pullRequest.getToRef().getLatestCommit();
+        String comment = format(BUILD_START_MARKER, builder.getJob().getDisplayName(), sourceCommit, destinationCommit);
+        StashPullRequestComment commentResponse = this.client.postPullRequestComment(pullRequest.getId(), comment);
+        return commentResponse.getCommentId().toString();
     }
 
     public static AbstractMap.SimpleEntry<String,String> getParameter(String content){
@@ -192,7 +192,7 @@ public class StashRepository {
 
     public void postFinishedComment(String pullRequestId, String sourceCommit,  String destinationCommit, Result buildResult, String buildUrl, int buildNumber, String additionalComment, String duration) {
         String message = getMessageForBuildResult(buildResult);
-        String comment = format(BUILD_FINISH_SENTENCE, builder.getProject().getDisplayName(), sourceCommit, destinationCommit, message, buildUrl, buildNumber, duration);
+        String comment = format(BUILD_FINISH_SENTENCE, builder.getJob().getDisplayName(), sourceCommit, destinationCommit, message, buildUrl, buildNumber, duration);
 
         comment = comment.concat(additionalComment);
 
@@ -233,7 +233,7 @@ public class StashRepository {
                         continue;
                     }
 
-                    String project_build_finished = format(BUILD_FINISH_REGEX, builder.getProject().getDisplayName());
+                    String project_build_finished = format(BUILD_FINISH_REGEX, builder.getJob().getDisplayName());
                     Matcher finishMatcher = Pattern.compile(project_build_finished, Pattern.CASE_INSENSITIVE).matcher(content);
 
                     if (finishMatcher.find()) {
@@ -289,7 +289,7 @@ public class StashRepository {
                     }
 
                     //These will match any start or finish message -- need to check commits
-                    String escapedBuildName = Pattern.quote(builder.getProject().getDisplayName());
+                    String escapedBuildName = Pattern.quote(builder.getJob().getDisplayName());
                     String project_build_start = String.format(BUILD_START_REGEX, escapedBuildName);
                     String project_build_finished = String.format(BUILD_FINISH_REGEX, escapedBuildName);
                     Matcher startMatcher = Pattern.compile(project_build_start, Pattern.CASE_INSENSITIVE).matcher(content);


### PR DESCRIPTION
Before this commit, if you attempted to use the Stash pull-request
builder plug in with Jenkins Pipeline, you would encounter an error.
Ultimately, this error was due to the fact that this plug in require
jobs to use the AbstractProject base class, but the Jenkins Pipeline
job class (WorkflowJob) doesn't.

The good news is that WorkflowJob and AbstractProject share a base
class of Job, and that most functionality of this plug in can be made
available to WorkflowJob refactoring uses of AbstractProject to uses
of Job instead.  For cases where this does not provide enough
functionality, there are interfaces implemented in common by both
(ParameterizedJobMixIn.ParameterizedJob, Queue.Task) that fill the
gaps.

The one remaining piece of functionality this commit does not extend
to be available to Jenkins Pipeline is custom post-build comments, so
a TODO to that effect was added.
