### PR TITLE
Add a checkProbeMergeStatus box just to probe Stash REST API…

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Select *Stash Pull Request Builder* then configure:
 - Rebuild if destination branch changes:
 - Build only if Stash reports no conflicts: this should be set if using the merge branch to avoid issues with out of data merge branch in stash
 - Build only if PR is mergeable (note this will stop the PR being built if you have required approvers limit set >0 and the PR hasn't been approved)
-- Probe the Stash REST API for merge status just so it recalculates the refspec: This probes the Stash REST API endpoint that causes recalculation of Git refspecs (see [JENKINS-35219](https://issues.jenkins-ci.org/browse/JENKINS-35219) and [Atlassian KB 239988](https://answers.atlassian.com/questions/239988/change-pull-request-refs-after-commit-instead-of-after-approval-or-workaround) for details). Has no impact on proceeding with the build itself, unlike the "Build only if..." options above.
+- Probe Stash for merge status: This probes the Stash REST API endpoint that causes recalculation of Git refspecs (see [JENKINS-35219](https://issues.jenkins-ci.org/browse/JENKINS-35219) and [Atlassian KB 239988](https://answers.atlassian.com/questions/239988/change-pull-request-refs-after-commit-instead-of-after-approval-or-workaround) for details). Has no impact on proceeding with the build itself, unlike the "Build only if..." options above.
 - Cancel outdated jobs
 - CI Skip Phrases: default: "NO TEST"
 - Only build when asked (with test phrase):

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Select *Stash Pull Request Builder* then configure:
 - Build PR targetting only these branches: common separated list of branch names (or regexes). Blank for all.
 - Rebuild if destination branch changes:
 - Build only if Stash reports no conflicts: this should be set if using the merge branch to avoid issues with out of data merge branch in stash
-- Build only if PR is mergeable (note this will stop the PR being built if you have required approvers limit set >0 and the PR hasn't been approved)
-- Probe Stash for merge status: This probes the Stash REST API endpoint that causes recalculation of Git refspecs (see [JENKINS-35219](https://issues.jenkins-ci.org/browse/JENKINS-35219) and [Atlassian KB 239988](https://answers.atlassian.com/questions/239988/change-pull-request-refs-after-commit-instead-of-after-approval-or-workaround) for details). Has no impact on proceeding with the build itself, unlike the "Build only if..." options above.
+- Build only if Stash reports PR is mergeable (note this will stop the PR being built if you have required approvers limit set >0 and the PR hasn't been approved)
+- Probe Stash for merge status: This just probes the Stash REST API endpoint that causes recalculation of Git refspecs (see [JENKINS-35219](https://issues.jenkins-ci.org/browse/JENKINS-35219) and [Atlassian KB 239988](https://answers.atlassian.com/questions/239988/change-pull-request-refs-after-commit-instead-of-after-approval-or-workaround) for details). Use this if you encounter problems with stale commits being built, but don't want to skip builds based on the PR status (as would be the case with the two options above). Also note that this option does not have any special effect if you have enabled one of the two options above.
 - Cancel outdated jobs
 - CI Skip Phrases: default: "NO TEST"
 - Only build when asked (with test phrase):

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Select *Stash Pull Request Builder* then configure:
 - Rebuild if destination branch changes:
 - Build only if Stash reports no conflicts: this should be set if using the merge branch to avoid issues with out of data merge branch in stash
 - Build only if PR is mergeable (note this will stop the PR being built if you have required approvers limit set >0 and the PR hasn't been approved)
-- Probe the Stash REST API for merge status just so it recalculates the refspec: This probes the Stash REST API endpoint that causes recalculation of Git refspecs (see https://issues.jenkins-ci.org/browse/JENKINS-35219 and https://answers.atlassian.com/questions/239988/change-pull-request-refs-after-commit-instead-of-after-approval-or-workaround for details). Has no impact on proceeding with the build itself.
+- Probe the Stash REST API for merge status just so it recalculates the refspec: This probes the Stash REST API endpoint that causes recalculation of Git refspecs (see [JENKINS-35219](https://issues.jenkins-ci.org/browse/JENKINS-35219) and [Atlassian KB 239988](https://answers.atlassian.com/questions/239988/change-pull-request-refs-after-commit-instead-of-after-approval-or-workaround) for details). Has no impact on proceeding with the build itself, unlike the "Build only if..." options above.
 - Cancel outdated jobs
 - CI Skip Phrases: default: "NO TEST"
 - Only build when asked (with test phrase):

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Select *Stash Pull Request Builder* then configure:
 - Rebuild if destination branch changes:
 - Build only if Stash reports no conflicts: this should be set if using the merge branch to avoid issues with out of data merge branch in stash
 - Build only if PR is mergeable (note this will stop the PR being built if you have required approvers limit set >0 and the PR hasn't been approved)
+- Probe the Stash REST API for merge status just so it recalculates the refspec: This probes the Stash REST API endpoint that causes recalculation of Git refspecs (see https://issues.jenkins-ci.org/browse/JENKINS-35219 and https://answers.atlassian.com/questions/239988/change-pull-request-refs-after-commit-instead-of-after-approval-or-workaround for details). Has no impact on proceeding with the build itself.
 - Cancel outdated jobs
 - CI Skip Phrases: default: "NO TEST"
 - Only build when asked (with test phrase):

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,16 @@
     </repository>
   </repositories>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>credentials</artifactId>
+                <version>2.1.13</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>	
+	
   <dependencies>
       <dependency>
           <groupId>commons-httpclient</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -56,34 +56,6 @@
          </dependency>
       </dependencies>
   </dependencyManagement>	
-	
-  <dependencies>
-      <dependency>
-          <groupId>commons-httpclient</groupId>
-          <artifactId>commons-httpclient</artifactId>
-          <version>3.1-jenkins-1</version>
-      </dependency>
-      <dependency>
-          <groupId>commons-codec</groupId>
-          <artifactId>commons-codec</artifactId>
-          <version>1.10</version>
-      </dependency>
-      <dependency>
-          <groupId>org.codehaus.jackson</groupId>
-          <artifactId>jackson-jaxrs</artifactId>
-          <version>1.9.13</version>
-      </dependency>
-      <dependency>
-          <groupId>org.jenkins-ci.plugins</groupId>
-          <artifactId>git</artifactId>
-          <version>4.0.0-rc3002.35b0975404eb</version>
-      </dependency>
-      <dependency>
-          <groupId>org.jenkins-ci.plugins</groupId>
-          <artifactId>credentials</artifactId>
-          <version>2.1.5</version>
-      </dependency>
-  </dependencies>  
   
   <dependencies>
     <dependency>
@@ -104,7 +76,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>3.0.0</version>
+      <version>4.0.0-rc3002.35b0975404eb</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <revision>1.7.1</revision>
     <changelist>-SNAPSHOT</changelist>
     <java.level>8</java.level>
-    <!--<jenkins.version>2.7.4</jenkins.version>-->
+    <jenkins.version>2.60.3</jenkins.version>
   </properties>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <revision>1.7.1</revision>
     <changelist>-SNAPSHOT</changelist>
     <java.level>8</java.level>
-    <jenkins.version>2.60.3</jenkins.version>
+    <jenkins.version>2.107.3</jenkins.version>
   </properties>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,19 +57,7 @@
     <revision>1.7.1</revision>
     <changelist>-SNAPSHOT</changelist>
     <java.level>8</java.level>
-    <jenkins.version>2.107.3</jenkins.version>
   </properties>
-
-
-  <dependencyManagement>
-      <dependencies>
-          <dependency>
-              <groupId>org.jenkins-ci.plugins</groupId>
-              <artifactId>credentials</artifactId>
-              <version>2.1.13</version>
-         </dependency>
-      </dependencies>
-  </dependencyManagement>	
   
   <dependencies>
     <dependency>
@@ -90,7 +78,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>4.0.0-rc3002.35b0975404eb</version>
+      <version>3.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>commons-httpclient</groupId>
       <artifactId>commons-httpclient</artifactId>
-      <version>3.1</version>
+      <version>3.1-jenkins-1</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,12 +58,12 @@
     <changelist>-SNAPSHOT</changelist>
     <java.level>8</java.level>
   </properties>
-  
+
   <dependencies>
     <dependency>
       <groupId>commons-httpclient</groupId>
       <artifactId>commons-httpclient</artifactId>
-      <version>3.1-jenkins-1</version>
+      <version>3.1</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
           <groupId>org.codehaus.jackson</groupId>
           <artifactId>jackson-jaxrs</artifactId>
           <version>1.9.13</version>
-      </dependency>  
+      </dependency>
       <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>git</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,14 @@
           <configuration>
             <excludeFilterFile>${basedir}/src/findbugs-exclude.xml</excludeFilterFile>
           </configuration>
-        </plugin>
+        </plugin> 
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <configuration>
+            <excludePackageNames>stashpullrequestbuilder.stashpullrequestbuilder.repackage.*</excludePackageNames>
+          </configuration>
+        </plugin>        
       </plugins>
     </pluginManagement>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
       <dependency>
           <groupId>commons-httpclient</groupId>
           <artifactId>commons-httpclient</artifactId>
-          <version>3.1</version>
+          <version>3.1-jenkins-1</version>
       </dependency>
       <dependency>
           <groupId>commons-codec</groupId>
@@ -68,11 +68,11 @@
           <groupId>org.codehaus.jackson</groupId>
           <artifactId>jackson-jaxrs</artifactId>
           <version>1.9.13</version>
-      </dependency>
+      </dependency>  
       <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>git</artifactId>
-          <version>3.0.0</version>
+          <version>4.0.0-rc3002.35b0975404eb</version>
       </dependency>
       <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,6 @@
           </configuration>
         </plugin> 
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <configuration>
             <excludePackageNames>stashpullrequestbuilder.stashpullrequestbuilder.repackage.*</excludePackageNames>

--- a/src/findbugs-exclude.xml
+++ b/src/findbugs-exclude.xml
@@ -11,6 +11,6 @@
      </Match>
 
      <Match>
-       <Package name="stashpullrequestbuilder.stashpullrequestbuilder.repackage.*" />
+       <Package name="~stashpullrequestbuilder\.stashpullrequestbuilder\.repackage\..*" />
      </Match>     
 </FindBugsFilter>

--- a/src/findbugs-exclude.xml
+++ b/src/findbugs-exclude.xml
@@ -10,4 +10,7 @@
        <Bug pattern="NP_NULL_ON_SOME_PATH" />
      </Match>
 
+     <Match>
+       <Package name="stashpullrequestbuilder.stashpullrequestbuilder.repackage.*" />
+     </Match>     
 </FindBugsFilter>

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -30,6 +30,7 @@ import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -63,10 +64,11 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     private final boolean checkMergeable;
     private final boolean mergeOnSuccess;
     private final boolean checkNotConflicted;
-    private final boolean checkProbeMergeStatus;
     private final boolean onlyBuildOnComment;
     private final boolean deletePreviousBuildFinishComments;
     private final boolean cancelOutdatedJobsEnabled;
+
+    private boolean checkProbeMergeStatus;
 
     transient private StashPullRequestsBuilder stashPullRequestsBuilder;
 
@@ -108,52 +110,16 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         this.checkMergeable = checkMergeable;
         this.mergeOnSuccess = mergeOnSuccess;
         this.checkNotConflicted = checkNotConflicted;
-        this.checkProbeMergeStatus = (checkNotConflicted || checkMergeable);
         this.onlyBuildOnComment = onlyBuildOnComment;
         this.deletePreviousBuildFinishComments = deletePreviousBuildFinishComments;
         this.targetBranchesToBuild = targetBranchesToBuild;
     }
 
-    @DataBoundConstructor
-    public StashBuildTrigger(
-            String projectPath,
-            String cron,
-            String stashHost,
-            String credentialsId,
-            String projectCode,
-            String repositoryName,
-            String ciSkipPhrases,
-            boolean ignoreSsl,
-            boolean checkDestinationCommit,
-            boolean checkMergeable,
-            boolean mergeOnSuccess,
-            boolean checkNotConflicted,
-            boolean checkProbeMergeStatus,
-            boolean onlyBuildOnComment,
-            String ciBuildPhrases,
-            boolean deletePreviousBuildFinishComments,
-            String targetBranchesToBuild,
-            boolean cancelOutdatedJobsEnabled
-    ) throws ANTLRException {
-        super(cron);
-        this.projectPath = projectPath;
-        this.cron = cron;
-        this.stashHost = stashHost;
-        this.credentialsId = credentialsId;
-        this.projectCode = projectCode;
-        this.repositoryName = repositoryName;
-        this.ciSkipPhrases = ciSkipPhrases;
-        this.cancelOutdatedJobsEnabled = cancelOutdatedJobsEnabled;
-        this.ciBuildPhrases = ciBuildPhrases == null ? "test this please" : ciBuildPhrases;
-        this.ignoreSsl = ignoreSsl;
-        this.checkDestinationCommit = checkDestinationCommit;
-        this.checkMergeable = checkMergeable;
-        this.mergeOnSuccess = mergeOnSuccess;
-        this.checkNotConflicted = checkNotConflicted;
+    @DataBoundSetter
+    public void setCheckProbeMergeStatus(
+        boolean checkProbeMergeStatus
+    ) {
         this.checkProbeMergeStatus = checkProbeMergeStatus;
-        this.onlyBuildOnComment = onlyBuildOnComment;
-        this.deletePreviousBuildFinishComments = deletePreviousBuildFinishComments;
-        this.targetBranchesToBuild = targetBranchesToBuild;
     }
 
     public String getStashHost() {

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -87,6 +87,47 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
             boolean checkMergeable,
             boolean mergeOnSuccess,
             boolean checkNotConflicted,
+            boolean onlyBuildOnComment,
+            String ciBuildPhrases,
+            boolean deletePreviousBuildFinishComments,
+            String targetBranchesToBuild,
+            boolean cancelOutdatedJobsEnabled
+    ) throws ANTLRException {
+        super(cron);
+        this.projectPath = projectPath;
+        this.cron = cron;
+        this.stashHost = stashHost;
+        this.credentialsId = credentialsId;
+        this.projectCode = projectCode;
+        this.repositoryName = repositoryName;
+        this.ciSkipPhrases = ciSkipPhrases;
+        this.cancelOutdatedJobsEnabled = cancelOutdatedJobsEnabled;
+        this.ciBuildPhrases = ciBuildPhrases == null ? "test this please" : ciBuildPhrases;
+        this.ignoreSsl = ignoreSsl;
+        this.checkDestinationCommit = checkDestinationCommit;
+        this.checkMergeable = checkMergeable;
+        this.mergeOnSuccess = mergeOnSuccess;
+        this.checkNotConflicted = checkNotConflicted;
+        this.checkProbeMergeStatus = (checkNotConflicted || checkMergeable);
+        this.onlyBuildOnComment = onlyBuildOnComment;
+        this.deletePreviousBuildFinishComments = deletePreviousBuildFinishComments;
+        this.targetBranchesToBuild = targetBranchesToBuild;
+    }
+
+    @DataBoundConstructor
+    public StashBuildTrigger(
+            String projectPath,
+            String cron,
+            String stashHost,
+            String credentialsId,
+            String projectCode,
+            String repositoryName,
+            String ciSkipPhrases,
+            boolean ignoreSsl,
+            boolean checkDestinationCommit,
+            boolean checkMergeable,
+            boolean mergeOnSuccess,
+            boolean checkNotConflicted,
             boolean checkProbeMergeStatus,
             boolean onlyBuildOnComment,
             String ciBuildPhrases,

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -63,6 +63,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     private final boolean checkMergeable;
     private final boolean mergeOnSuccess;
     private final boolean checkNotConflicted;
+    private final boolean checkProbeMergeStatus;
     private final boolean onlyBuildOnComment;
     private final boolean deletePreviousBuildFinishComments;
     private final boolean cancelOutdatedJobsEnabled;
@@ -86,6 +87,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
             boolean checkMergeable,
             boolean mergeOnSuccess,
             boolean checkNotConflicted,
+            boolean checkProbeMergeStatus,
             boolean onlyBuildOnComment,
             String ciBuildPhrases,
             boolean deletePreviousBuildFinishComments,
@@ -107,6 +109,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         this.checkMergeable = checkMergeable;
         this.mergeOnSuccess = mergeOnSuccess;
         this.checkNotConflicted = checkNotConflicted;
+        this.checkProbeMergeStatus = checkProbeMergeStatus;
         this.onlyBuildOnComment = onlyBuildOnComment;
         this.deletePreviousBuildFinishComments = deletePreviousBuildFinishComments;
         this.targetBranchesToBuild = targetBranchesToBuild;
@@ -312,6 +315,10 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
     public boolean isCheckNotConflicted() {
         return checkNotConflicted;
+    }
+
+    public boolean isCheckProbeMergeStatus() {
+        return checkProbeMergeStatus;
     }
 
     public boolean isOnlyBuildOnComment() {

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -213,20 +213,19 @@ public class StashRepository {
             if (trigger.isCheckNotConflicted())
                 res = res && !mergable.getConflicted();
 
-            if (trigger.isCheckProbeMergeStatus()) {
-                /* Just probe the REST API, so Stash updates the refspecs
-                 * (it does so lazily to reduce server load, until someone
-                 * requests a refresh).
-                 *
-                 * This is a workaround for a case of broken git references
-                 * that appear due to pull requests, popping up in other jobs
-                 * trying to use e.g. just the master branch.
-                 *
-                 * See https://issues.jenkins-ci.org/browse/JENKINS-35219 and
-                 * https://community.atlassian.com/t5/Bitbucket-questions/Change-pull-request-refs-after-Commit-instead-of-after-Approval/qaq-p/194702
-                 */
-                return true;
-            }
+            /* The trigger.isCheckProbeMergeStatus() consulted above
+             * is for when a user wants to just probe the Stash REST API
+             * call, so Stash updates the refspecs (by design it does
+             * so "lazily" to reduce server load, that is until someone
+             * requests a refresh).
+             *
+             * This is a workaround for a case of broken git references
+             * that appear due to pull requests, even popping up in other
+             * jobs trying to use e.g. just the master branch.
+             *
+             * See https://issues.jenkins-ci.org/browse/JENKINS-35219 and
+             * https://community.atlassian.com/t5/Bitbucket-questions/Change-pull-request-refs-after-Commit-instead-of-after-Approval/qaq-p/194702
+             */
 
             return res;
         }

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -215,9 +215,12 @@ public class StashRepository {
 
             if (trigger.isCheckProbeMergeStatus()) {
                 /* Just probe the REST API, so Stash updates the refspecs
+                 * (it does so lazily to reduce server load, until someone
+                 * requests a refresh).
                  *
-                 * Workaround for broken git references that appear due to PRs,
-                 * popping up in other jobs trying to use just the master branch.
+                 * This is a workaround for a case of broken git references
+                 * that appear due to pull requests, popping up in other jobs
+                 * trying to use e.g. just the master branch.
                  *
                  * See https://issues.jenkins-ci.org/browse/JENKINS-35219 and
                  * https://community.atlassian.com/t5/Bitbucket-questions/Change-pull-request-refs-after-Commit-instead-of-after-Approval/qaq-p/194702

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -206,6 +206,11 @@ public class StashRepository {
 
     private Boolean isPullRequestMergable(StashPullRequestResponseValue pullRequest) {
         if (trigger.isCheckMergeable() || trigger.isCheckNotConflicted() || trigger.isCheckProbeMergeStatus()) {
+            /* Request PR status from Stash, and consult our configuration
+             * toggles on whether we care about certain verdicts in that
+             * JSON answer, parsed into fields of the "response" object.
+             * See example in StashApiClientTest.java.
+             */
             StashPullRequestMergableResponse mergable = client.getPullRequestMergeStatus(pullRequest.getId());
             boolean res = true;
             if (trigger.isCheckMergeable())

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -205,13 +205,26 @@ public class StashRepository {
     }
 
     private Boolean isPullRequestMergable(StashPullRequestResponseValue pullRequest) {
-        if (trigger.isCheckMergeable() || trigger.isCheckNotConflicted()) {
+        if (trigger.isCheckMergeable() || trigger.isCheckNotConflicted() || trigger.isCheckProbeMergeStatus()) {
             StashPullRequestMergableResponse mergable = client.getPullRequestMergeStatus(pullRequest.getId());
             boolean res = true;
             if (trigger.isCheckMergeable())
                 res = res && mergable.getCanMerge();
             if (trigger.isCheckNotConflicted())
                 res = res && !mergable.getConflicted();
+
+            if (trigger.isCheckProbeMergeStatus()) {
+                /* Just probe the REST API, so Stash updates the refspecs
+                 *
+                 * Workaround for broken git references that appear due to PRs,
+                 * popping up in other jobs trying to use just the master branch.
+                 *
+                 * See https://issues.jenkins-ci.org/browse/JENKINS-35219 and
+                 * https://community.atlassian.com/t5/Bitbucket-questions/Change-pull-request-refs-after-Commit-instead-of-after-Approval/qaq-p/194702
+                 */
+                return true;
+            }
+
             return res;
         }
         return true;

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/repackage/org/apache/commons/httpclient/contrib/ssl/EasySSLProtocolSocketFactory.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/repackage/org/apache/commons/httpclient/contrib/ssl/EasySSLProtocolSocketFactory.java
@@ -1,0 +1,230 @@
+/*
+ * $Header: /home/jerenkrantz/tmp/commons/commons-convert/cvs/home/cvs/jakarta-commons//httpclient/src/contrib/org/apache/commons/httpclient/contrib/ssl/EasySSLProtocolSocketFactory.java,v 1.7 2004/06/11 19:26:27 olegk Exp $
+ * $Revision: 480424 $
+ * $Date: 2006-11-29 06:56:49 +0100 (Wed, 29 Nov 2006) $
+ * 
+ * ====================================================================
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package stashpullrequestbuilder.stashpullrequestbuilder.repackage.org.apache.commons.httpclient.contrib.ssl;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.UnknownHostException;
+
+import org.apache.commons.httpclient.ConnectTimeoutException;
+import org.apache.commons.httpclient.HttpClientError;
+import org.apache.commons.httpclient.params.HttpConnectionParams;
+import org.apache.commons.httpclient.protocol.SecureProtocolSocketFactory;
+import org.apache.commons.logging.Log; 
+import org.apache.commons.logging.LogFactory;
+
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+
+/**
+ * <p>
+ * EasySSLProtocolSocketFactory can be used to creats SSL {@link Socket}s 
+ * that accept self-signed certificates. 
+ * </p>
+ * <p>
+ * This socket factory SHOULD NOT be used for productive systems 
+ * due to security reasons, unless it is a concious decision and 
+ * you are perfectly aware of security implications of accepting 
+ * self-signed certificates
+ * </p>
+ *
+ * <p>
+ * Example of using custom protocol socket factory for a specific host:
+ *     <pre>
+ *     Protocol easyhttps = new Protocol("https", new EasySSLProtocolSocketFactory(), 443);
+ *
+ *     HttpClient client = new HttpClient();
+ *     client.getHostConfiguration().setHost("localhost", 443, easyhttps);
+ *     // use relative url only
+ *     GetMethod httpget = new GetMethod("/");
+ *     client.executeMethod(httpget);
+ *     </pre>
+ * </p>
+ * <p>
+ * Example of using custom protocol socket factory per default instead of the standard one:
+ *     <pre>
+ *     Protocol easyhttps = new Protocol("https", new EasySSLProtocolSocketFactory(), 443);
+ *     Protocol.registerProtocol("https", easyhttps);
+ *
+ *     HttpClient client = new HttpClient();
+ *     GetMethod httpget = new GetMethod("https://localhost/");
+ *     client.executeMethod(httpget);
+ *     </pre>
+ * </p>
+ * 
+ * @author <a href="mailto:oleg -at- ural.ru">Oleg Kalnichevski</a>
+ * 
+ * <p>
+ * DISCLAIMER: HttpClient developers DO NOT actively support this component.
+ * The component is provided as a reference material, which may be inappropriate
+ * for use without additional customization.
+ * </p>
+ */
+
+public class EasySSLProtocolSocketFactory implements SecureProtocolSocketFactory {
+
+    /** Log object for this class. */
+    private static final Log LOG = LogFactory.getLog(EasySSLProtocolSocketFactory.class);
+
+    private SSLContext sslcontext = null;
+
+    /**
+     * Constructor for EasySSLProtocolSocketFactory.
+     */
+    public EasySSLProtocolSocketFactory() {
+        super();
+    }
+
+    private static SSLContext createEasySSLContext() {
+        try {
+            SSLContext context = SSLContext.getInstance("SSL");
+            context.init(
+              null, 
+              new TrustManager[] {new EasyX509TrustManager(null)}, 
+              null);
+            return context;
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+            throw new HttpClientError(e.toString());
+        }
+    }
+
+    private SSLContext getSSLContext() {
+        if (this.sslcontext == null) {
+            this.sslcontext = createEasySSLContext();
+        }
+        return this.sslcontext;
+    }
+
+    /**
+     * @see SecureProtocolSocketFactory#createSocket(java.lang.String,int,java.net.InetAddress,int)
+     */
+    public Socket createSocket(
+        String host,
+        int port,
+        InetAddress clientHost,
+        int clientPort)
+        throws IOException, UnknownHostException {
+
+        return getSSLContext().getSocketFactory().createSocket(
+            host,
+            port,
+            clientHost,
+            clientPort
+        );
+    }
+
+    /**
+     * Attempts to get a new socket connection to the given host within the given time limit.
+     * <p>
+     * To circumvent the limitations of older JREs that do not support connect timeout a 
+     * controller thread is executed. The controller thread attempts to create a new socket 
+     * within the given limit of time. If socket constructor does not return until the 
+     * timeout expires, the controller terminates and throws an {@link ConnectTimeoutException}
+     * </p>
+     *  
+     * @param host the host name/IP
+     * @param port the port on the host
+     * @param clientHost the local host name/IP to bind the socket to
+     * @param clientPort the port on the local machine
+     * @param params {@link HttpConnectionParams Http connection parameters}
+     * 
+     * @return Socket a new socket
+     * 
+     * @throws IOException if an I/O error occurs while creating the socket
+     * @throws UnknownHostException if the IP address of the host cannot be
+     * determined
+     */
+    public Socket createSocket(
+        final String host,
+        final int port,
+        final InetAddress localAddress,
+        final int localPort,
+        final HttpConnectionParams params
+    ) throws IOException, UnknownHostException, ConnectTimeoutException {
+        if (params == null) {
+            throw new IllegalArgumentException("Parameters may not be null");
+        }
+        int timeout = params.getConnectionTimeout();
+        SocketFactory socketfactory = getSSLContext().getSocketFactory();
+        if (timeout == 0) {
+            return socketfactory.createSocket(host, port, localAddress, localPort);
+        } else {
+            Socket socket = socketfactory.createSocket();
+            SocketAddress localaddr = new InetSocketAddress(localAddress, localPort);
+            SocketAddress remoteaddr = new InetSocketAddress(host, port);
+            socket.bind(localaddr);
+            socket.connect(remoteaddr, timeout);
+            return socket;
+        }
+    }
+
+    /**
+     * @see SecureProtocolSocketFactory#createSocket(java.lang.String,int)
+     */
+    public Socket createSocket(String host, int port)
+        throws IOException, UnknownHostException {
+        return getSSLContext().getSocketFactory().createSocket(
+            host,
+            port
+        );
+    }
+
+    /**
+     * @see SecureProtocolSocketFactory#createSocket(java.net.Socket,java.lang.String,int,boolean)
+     */
+    public Socket createSocket(
+        Socket socket,
+        String host,
+        int port,
+        boolean autoClose)
+        throws IOException, UnknownHostException {
+        return getSSLContext().getSocketFactory().createSocket(
+            socket,
+            host,
+            port,
+            autoClose
+        );
+    }
+
+    public boolean equals(Object obj) {
+        return ((obj != null) && obj.getClass().equals(EasySSLProtocolSocketFactory.class));
+    }
+
+    public int hashCode() {
+        return EasySSLProtocolSocketFactory.class.hashCode();
+    }
+
+}

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/repackage/org/apache/commons/httpclient/contrib/ssl/EasyX509TrustManager.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/repackage/org/apache/commons/httpclient/contrib/ssl/EasyX509TrustManager.java
@@ -1,0 +1,114 @@
+/*
+ * ====================================================================
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package stashpullrequestbuilder.stashpullrequestbuilder.repackage.org.apache.commons.httpclient.contrib.ssl;
+
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import org.apache.commons.logging.Log; 
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * <p>
+ * EasyX509TrustManager unlike default {@link X509TrustManager} accepts 
+ * self-signed certificates. 
+ * </p>
+ * <p>
+ * This trust manager SHOULD NOT be used for productive systems 
+ * due to security reasons, unless it is a concious decision and 
+ * you are perfectly aware of security implications of accepting 
+ * self-signed certificates
+ * </p>
+ * 
+ * @author <a href="mailto:adrian.sutton@ephox.com">Adrian Sutton</a>
+ * @author <a href="mailto:oleg@ural.ru">Oleg Kalnichevski</a>
+ * 
+ * <p>
+ * DISCLAIMER: HttpClient developers DO NOT actively support this component.
+ * The component is provided as a reference material, which may be inappropriate
+ * for use without additional customization.
+ * </p>
+ */
+
+public class EasyX509TrustManager implements X509TrustManager
+{
+    private X509TrustManager standardTrustManager = null;
+
+    /** Log object for this class. */
+    private static final Log LOG = LogFactory.getLog(EasyX509TrustManager.class);
+
+    /**
+     * Constructor for EasyX509TrustManager.
+     */
+    public EasyX509TrustManager(KeyStore keystore) throws NoSuchAlgorithmException, KeyStoreException {
+        super();
+        TrustManagerFactory factory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        factory.init(keystore);
+        TrustManager[] trustmanagers = factory.getTrustManagers();
+        if (trustmanagers.length == 0) {
+            throw new NoSuchAlgorithmException("no trust manager found");
+        }
+        this.standardTrustManager = (X509TrustManager)trustmanagers[0];
+    }
+
+    /**
+     * @see javax.net.ssl.X509TrustManager#checkClientTrusted(X509Certificate[],String authType)
+     */
+    public void checkClientTrusted(X509Certificate[] certificates,String authType) throws CertificateException {
+        standardTrustManager.checkClientTrusted(certificates,authType);
+    }
+
+    /**
+     * @see javax.net.ssl.X509TrustManager#checkServerTrusted(X509Certificate[],String authType)
+     */
+    public void checkServerTrusted(X509Certificate[] certificates,String authType) throws CertificateException {
+        if ((certificates != null) && LOG.isDebugEnabled()) {
+            LOG.debug("Server certificate chain:");
+            for (int i = 0; i < certificates.length; i++) {
+                LOG.debug("X509Certificate[" + i + "]=" + certificates[i]);
+            }
+        }
+        if ((certificates != null) && (certificates.length == 1)) {
+            certificates[0].checkValidity();
+        } else {
+            standardTrustManager.checkServerTrusted(certificates,authType);
+        }
+    }
+
+    /**
+     * @see javax.net.ssl.X509TrustManager#getAcceptedIssuers()
+     */
+    public X509Certificate[] getAcceptedIssuers() {
+        return this.standardTrustManager.getAcceptedIssuers();
+    }
+}

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
@@ -473,7 +473,8 @@ public class StashApiClient {
         return basePath.substring(0, basePath.length() - 1) + "?start=" + start;
     }
 
-    private static class EasySSLProtocolSocketFactory extends org.apache.commons.httpclient.contrib.ssl.EasySSLProtocolSocketFactory {
+    private static class EasySSLProtocolSocketFactory 
+	    extends  stashpullrequestbuilder.stashpullrequestbuilder.repackage.org.apache.commons.httpclient.contrib.ssl.EasySSLProtocolSocketFactory {
         private static final Log LOG = LogFactory.getLog(EasySSLProtocolSocketFactory.class);
         private SSLContext sslcontext = null;
 

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
@@ -32,7 +32,7 @@
       <f:checkbox default="false"/>
     </f:entry>
     <f:entry title="Probe Stash for merge status" field="checkProbeMergeStatus">
-      <f:checkbox default="true"/>
+      <f:checkbox default="false"/>
     </f:entry>
     <f:entry title="Merge PR if build is successful" field="mergeOnSuccess">
         <f:checkbox default="false"/>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
@@ -31,6 +31,9 @@
     <f:entry title="Build only if PR is mergeable" field="checkMergeable">
       <f:checkbox default="false"/>
     </f:entry>
+    <f:entry title="Probe the Stash REST API for merge status just so it recalculates the refspec" field="checkProbeMergeStatus">
+      <f:checkbox default="true"/>
+    </f:entry>
     <f:entry title="Merge PR if build is successful" field="mergeOnSuccess">
         <f:checkbox default="false"/>
     </f:entry>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
@@ -31,7 +31,7 @@
     <f:entry title="Build only if PR is mergeable" field="checkMergeable">
       <f:checkbox default="false"/>
     </f:entry>
-    <f:entry title="Probe the Stash REST API for merge status just so it recalculates the refspec" field="checkProbeMergeStatus">
+    <f:entry title="Probe Stash for merge status" field="checkProbeMergeStatus">
       <f:checkbox default="true"/>
     </f:entry>
     <f:entry title="Merge PR if build is successful" field="mergeOnSuccess">

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
@@ -28,7 +28,7 @@
     <f:entry title="Build only if Stash reports no conflicts" field="checkNotConflicted">
       <f:checkbox default="true"/>
     </f:entry>
-    <f:entry title="Build only if PR is mergeable" field="checkMergeable">
+    <f:entry title="Build only if Stash reports PR is mergeable" field="checkMergeable">
       <f:checkbox default="false"/>
     </f:entry>
     <f:entry title="Probe Stash for merge status" field="checkProbeMergeStatus">

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-checkProbeMergeStatus.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-checkProbeMergeStatus.html
@@ -5,6 +5,13 @@
     Unlike the "Build only if..." options, this one has no impact on
     proceeding with the build itself.<br/>
 
+    Use this if you encounter problems with stale commits being built,
+    but don't want to skip builds based on the PR status (as would be
+    the case with the "Build only if Stash reports no conflicts" or
+    "Build only if Stash reports PR is mergeable" options). Also note
+    that this option does not have any special effect if you have
+    enabled one of those two options.<br/>
+
     Normally Stash has a "lazy" recalculation, after a request to do so
     (which may be part of Stash Web-UI processing among other things),
     in order to avoid server load spikes whenever a source or target

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-checkProbeMergeStatus.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-checkProbeMergeStatus.html
@@ -1,0 +1,18 @@
+<div>
+    Probe the Stash REST API for merge status just so it recalculates the
+    refspec: this just causes the plugin to send a request to the Stash
+    REST API endpoint which triggers recalculation of Git refspecs.
+    Unlike the "Build only if..." options, this one has no impact on
+    proceeding with the build itself.<br/>
+
+    Normally Stash has a "lazy" recalculation, after a request to do so
+    (which may be part of Stash Web-UI processing among other things),
+    in order to avoid server load spikes whenever a source or target
+    branch of a pull request changes.<br/>
+
+    For more details see
+    <a href="https://issues.jenkins-ci.org/browse/JENKINS-35219">JENKINS-35219
+    issue</a> and
+    <a href="https://answers.atlassian.com/questions/239988/change-pull-request-refs-after-commit-instead-of-after-approval-or-workaround">Atlassian
+    discussion</a> for details).
+</div>


### PR DESCRIPTION
…in order to recalculate refspecs and so work around the Stash feature of lazy reference recalculation as branches evolve. Defaults to "on" because another feature (check for conflicts) that calls same REST API - but can actively refuse to build the PR - defaults to "on".

Hopefully solves https://issues.jenkins-ci.org/browse/JENKINS-35219