### PR TITLE
Clarify that "Stash Host" is a REST API URL, not a plain hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Select *Git* then configure:
 Select *Stash Pull Request Builder* then configure:
 
 - **Cron**: must be specified. eg: every 2 minute `H/2 * * * *`
-- **Stash REST API Host (HTTP URL)**: the *http* or *https* URL of the Stash host (NOT *ssh*). eg: *https://example.com*
-- **Stash Credentials**: Select or Add the login username/password for the Stash Host (NOT ssh key)
+- **Stash URL**: the *http* or *https* URL of the Stash REST API Host (NOT *ssh*). eg: *https://example.com*
+- **Stash Credentials**: Select or Add the login username/password for the Stash REST API Host (NOT ssh key)
 - **Project**: abbreviated project code. eg: *PRJ* or *~user*
 - **RepositoryName**: eg: *Repo*
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Select *Git* then configure:
 Select *Stash Pull Request Builder* then configure:
 
 - **Cron**: must be specified. eg: every 2 minute `H/2 * * * *`
-- **Stash Host**: the *http* or *https* URL of the Stash host (NOT *ssh*). eg: *https://example.com*
-- **Stash Credentials**: Select or Add the login username/password for the Stash Host
+- **Stash REST API Host (HTTP URL)**: the *http* or *https* URL of the Stash host (NOT *ssh*). eg: *https://example.com*
+- **Stash Credentials**: Select or Add the login username/password for the Stash Host (NOT ssh key)
 - **Project**: abbreviated project code. eg: *PRJ* or *~user*
 - **RepositoryName**: eg: *Repo*
 

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
@@ -3,7 +3,7 @@
   <f:entry title="Cron" field="cron">
     <f:textbox />
   </f:entry>
-  <f:entry title="Stash REST API Host (HTTP URL)" field="stashHost">
+  <f:entry title="Stash URL" field="stashHost">
       <f:textbox />
   </f:entry>
   <f:entry title="Stash Credentials (username/password)" field="credentialsId">

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
@@ -3,7 +3,7 @@
   <f:entry title="Cron" field="cron">
     <f:textbox />
   </f:entry>
-  <f:entry title="Stash Host" field="stashHost">
+  <f:entry title="Stash REST API Host (HTTP URL)" field="stashHost">
       <f:textbox />
   </f:entry>
   <f:entry title="Stash Credentials (username/password)" field="credentialsId">


### PR DESCRIPTION
Just a cosmetic change in README and GUI resources, but very helpful for first-time users of the plugin :)