### PR TITLE
StashBuilds.java : try again before asking to "PLEASE SET JENKINS ROOT URL…

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
@@ -49,24 +49,11 @@ public class StashBuilds {
             return;
         }
         Result result = build.getResult();
-        JenkinsLocationConfiguration globalConfig = new JenkinsLocationConfiguration();
+        // Note: current code should no longer use "new JenkinsLocationConfiguration()"
+        // as only one instance per runtime is really supported by the current core.
+        JenkinsLocationConfiguration globalConfig = JenkinsLocationConfiguration.get();
         String rootUrl = globalConfig.getUrl();
         String buildUrl = "";
-        if (rootUrl == null) {
-            // Get hold of the currently active config, if this version
-            // of Jenkins core returns an empty one as new()
-            try {
-                globalConfig.load();
-                rootUrl = globalConfig.getUrl();
-            } catch (Exception e) {}
-        }
-        if (rootUrl == null) {
-            // Another method to try getting the active config...
-            try {
-                globalConfig = JenkinsLocationConfiguration.get();
-                rootUrl = globalConfig.getUrl();
-            } catch (Exception e) {}
-        }
         if (rootUrl == null) {
             buildUrl = " PLEASE SET JENKINS ROOT URL FROM GLOBAL CONFIGURATION " + build.getUrl();
         }

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
@@ -55,8 +55,17 @@ public class StashBuilds {
         if (rootUrl == null) {
             // Get hold of the currently active config, if this version
             // of Jenkins core returns an empty one as new()
-            globalConfig = JenkinsLocationConfiguration.get();
-            rootUrl = globalConfig.getUrl();
+            try {
+                globalConfig.load();
+                rootUrl = globalConfig.getUrl();
+            } catch (Exception e) {}
+        }
+        if (rootUrl == null) {
+            // Another method to try getting the active config...
+            try {
+                globalConfig = JenkinsLocationConfiguration.get();
+                rootUrl = globalConfig.getUrl();
+            } catch (Exception e) {}
         }
         if (rootUrl == null) {
             buildUrl = " PLEASE SET JENKINS ROOT URL FROM GLOBAL CONFIGURATION " + build.getUrl();

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
@@ -53,6 +53,12 @@ public class StashBuilds {
         String rootUrl = globalConfig.getUrl();
         String buildUrl = "";
         if (rootUrl == null) {
+            // Get hold of the currently active config, if this version
+            // of Jenkins core returns an empty one as new()
+            globalConfig = JenkinsLocationConfiguration.get();
+            rootUrl = globalConfig.getUrl();
+        }
+        if (rootUrl == null) {
             buildUrl = " PLEASE SET JENKINS ROOT URL FROM GLOBAL CONFIGURATION " + build.getUrl();
         }
         else {

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
@@ -52,7 +52,7 @@ public class StashBuilds {
         // Note: current code should no longer use "new JenkinsLocationConfiguration()"
         // as only one instance per runtime is really supported by the current core.
         JenkinsLocationConfiguration globalConfig = JenkinsLocationConfiguration.get();
-        String rootUrl = globalConfig.getUrl();
+        String rootUrl = globalConfig == null ? null : globalConfig.getUrl();
         String buildUrl = "";
         if (rootUrl == null) {
             buildUrl = " PLEASE SET JENKINS ROOT URL FROM GLOBAL CONFIGURATION " + build.getUrl();


### PR DESCRIPTION
…FROM GLOBAL CONFIGURATION"

https://stackoverflow.com/questions/30355079/jenkins-setting-root-url-via-groovy-api was helpful :)

Note: apparently, https://github.com/jenkinsci/jenkins/commit/c3988aae8ad66fde529830e799fe3d49cd241ebb#diff-1439884ddd002c6ca6463d9657412b15 from Aug 18 2018 broke the earlier working setups, since the constructors doing `load()` were removed with it. Which sort of contradicts some discussion threads from much earlier ages, that the constructor makes a new empty object so a `get()` of existing config should be done. But not being much of a Java developer, I might read it wrong... still, it matches our server's mis-behavior starting a few weeks ago after an update.