### PR TITLE
Remove problematic maven-compiler-plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,6 @@
           </dependency>
         </dependencies>
       </plugin>
-
       <plugin>
         <groupId>com.github.ekryd.sortpom</groupId>
         <artifactId>sortpom-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -114,15 +114,7 @@
           </dependency>
         </dependencies>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
-        <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
-        </configuration>
-      </plugin>
+
       <plugin>
         <groupId>com.github.ekryd.sortpom</groupId>
         <artifactId>sortpom-maven-plugin</artifactId>


### PR DESCRIPTION
The `source` and `target` should be configured via `java.level`
which is used by the parent pom.