### PR TITLE
Remove obsolete maven-release-plugin workaround

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,18 +104,6 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.1</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.apache.maven.scm</groupId>
-            <artifactId>maven-scm-provider-gitexe</artifactId>
-            <version>1.9.2</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.3</version>
         <configuration>


### PR DESCRIPTION
The current parent pom requires maven-release-plugin 2.5.3 which itself
requires maven-scm-api & maven-scm-provider-gitexe 1.9.4.