### PR TITLE
Add help files for all fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,24 +42,25 @@ Select *Git* then configure:
 
 Select *Stash Pull Request Builder* then configure:
 
-- **Cron**: must be specified. eg: every 2 minute `H/2 * * * *`
-- **Stash URL**: the *http* or *https* URL of the Stash REST API Host (NOT *ssh*). eg: *https://example.com*
-- **Stash Credentials**: Select or Add the login username/password for the Stash REST API Host (NOT ssh key)
-- **Project**: abbreviated project code. eg: *PRJ* or *~user*
-- **RepositoryName**: eg: *Repo*
+- **Cron schedule**: How often to poll, e.g. every 2 minute: `H/2 * * * *`
+- **Stash URL**: The *http* or *https* URL of the Stash REST API (*NOT* ssh), e.g. *https://stash.example.com/*
+- **Stash credentials**: Select or add username and password for the Stash REST API (*NOT* an ssh key).
+- **Project**: Project key (i.e. an abbreviated project name), e.g. *PRJ* or *~user*
+- **RepositoryName**: Name of the Stash repository to be polled, e.g. *Repo*
 
 **Advanced options**
-- Ignore ssl certificates:
-- Build PR targeting only these branches: common separated list of branch names (or regexes). Blank for all.
-- Rebuild if destination branch changes:
-- Build only if Stash reports no conflicts: this should be set if using the merge branch to avoid issues with out-of-date merge branch in Stash
-- Build only if Stash reports PR is mergeable (note this will stop the PR being built if you have required approvers limit set >0 and the PR hasn't been approved)
-- Probe Stash for merge status: This just probes the Stash REST API endpoint that causes recalculation of Git refspecs (see [JENKINS-35219](https://issues.jenkins-ci.org/browse/JENKINS-35219) and [Atlassian KB 239988](https://answers.atlassian.com/questions/239988/change-pull-request-refs-after-commit-instead-of-after-approval-or-workaround) for details). Use this if you encounter problems with stale commits being built, but don't want to skip builds based on the PR status (as would be the case with the two options above). Also note that this option does not have any special effect if you have enabled one of the two options above.
-- Cancel outdated jobs
-- CI Skip Phrases: default: "NO TEST"
-- Only build when asked (with test phrase):
-- CI Build Phrases: default: "test this please"
-- Target branches: a comma separated list of branches (e.g. brancha,branchb)
+- **Ignore SSL certificates**: Allow invalid or unverifiable (e.g. self-signed) certificates to access Stash REST API over https.
+- **Build PR targeting only these branches**: Comma separated list of branch names (or regexes), blank for all branches.
+- **Rebuild if destination branch changes**: Start the build if the destination commit has changed, i.e. some changes have been made on the target branch.
+- **Build only if Stash reports no conflicts**: Don't build PRs in the "conflict" state. This should be set if using the merge refspec, as Stash doesn't provide the merge refspec for conflicted PRs.
+- **Build only if Stash reports PR is mergeable**: Build if the PR only if Stash allows merging it. *NOTE:* If the PR doesn't have the required number of approvals, the PR would not be tested when this option is enabled.
+- **Probe Stash for merge status**: This just probes the Stash REST API endpoint that causes recalculation of Git refspecs (see [JENKINS-35219](https://issues.jenkins-ci.org/browse/JENKINS-35219) and [Atlassian KB 239988](https://answers.atlassian.com/questions/239988/change-pull-request-refs-after-commit-instead-of-after-approval-or-workaround) for details). Use this if you encounter problems with stale commits being built, but don't want to skip builds based on the PR status (as would be the case with the two options above). Also note that this option does not have any special effect if you have enabled one of the two options above.
+- **Merge PR if build is successful**: Tell Stash to merge the PR automatically if the build job has been successful.
+- **Keep PR comment only for most recent build**: Delete old comments about finished PR builds when starting a new build.
+- **Cancel outdated jobs**: Cancel all jobs in the queue for the same PR.
+- **Phrase to disable builds**: Don't build the PR if the specified phrase has been posted in a PR comment. Default: *NO TEST*
+- **Only build if asked with the build phrase**: Only trigger the build when the build phrase has been posted.
+- **Phrase to request a build**: Build the PR if the specified phrase has been posted as a PR comment in Stash, even if the PR has not changed. Default: *test this please*
 
 ## Building the merge of Source Branch into Target Branch
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Select *Stash Pull Request Builder* then configure:
 - **Cancel outdated jobs**: Cancel all jobs in the queue for the same PR.
 - **Phrase to disable builds**: Don't build the PR if the specified phrase has been posted in a PR comment. Default: *NO TEST*
 - **Only build if asked with the build phrase**: Only trigger the build when the build phrase has been posted.
-- **Phrase to request a build**: Build the PR if the specified phrase has been posted as a PR comment in Stash, even if the PR has not changed. Default: *test this please*
+- **Phrase to request a build**: Force (re-)building the PR if the specified phrase has been posted as a PR comment in Stash. This is useful when a build fails due to circumstances unrelated to the codebase. Starting a build in Jenkins GUI won't work, as the pull request data won't be available. Default: *test this please*
 
 ## Building the merge of Source Branch into Target Branch
 

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -344,7 +344,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
         @Override
         public String getDisplayName() {
-            return "Stash Pull Requests Builder";
+            return "Stash pull request builder";
         }
 
         @Override

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPostBuildComment.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPostBuildComment.java
@@ -95,7 +95,7 @@ public class StashPostBuildComment extends Notifier {
 
         @Override
         public String getDisplayName() {
-            return "Stash Pull Request Builder - Post Build Comment";
+            return "Stash pull request builder - post build comment";
         }
     }
 }

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
@@ -49,7 +49,7 @@
     <f:entry title="Only build if asked with the build phrase" field="onlyBuildOnComment">
       <f:checkbox default="false"/>
     </f:entry>
-    <f:entry title="Phrase to request a build" field="ciBuildPhrases">
+    <f:entry title="Phrase to request a (re-)build" field="ciBuildPhrases">
       <f:textbox default="test this please"/>
     </f:entry>
   </f:advanced>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
-  <f:entry title="Cron" field="cron">
+  <f:entry title="Cron schedule" field="cron">
     <f:textbox />
   </f:entry>
   <f:entry title="Stash URL" field="stashHost">
@@ -16,7 +16,7 @@
     <f:textbox />
   </f:entry>
   <f:advanced>
-    <f:entry title="Ignore ssl certificates" field="ignoreSsl">
+    <f:entry title="Ignore SSL certificates" field="ignoreSsl">
       <f:checkbox default="false"/>
     </f:entry>
     <f:entry title="Build PR targeting only these branches" field="targetBranchesToBuild">
@@ -37,19 +37,19 @@
     <f:entry title="Merge PR if build is successful" field="mergeOnSuccess">
         <f:checkbox default="false"/>
     </f:entry>
-    <f:entry title="Keep PR comment only for most recent Build" field="deletePreviousBuildFinishComments">
+    <f:entry title="Keep PR comment only for most recent build" field="deletePreviousBuildFinishComments">
       <f:checkbox default="false"/>
     </f:entry>
     <f:entry title="Cancel outdated jobs" field="cancelOutdatedJobsEnabled">
       <f:checkbox default="false"/>
     </f:entry>
-    <f:entry title="CI Skip Phrases" field="ciSkipPhrases">
+    <f:entry title="Phrase to disable builds" field="ciSkipPhrases">
       <f:textbox default="NO TEST" />
     </f:entry>
-    <f:entry title="Only build when asked (with test phrase)" field="onlyBuildOnComment">
+    <f:entry title="Only build if asked with the build phrase" field="onlyBuildOnComment">
       <f:checkbox default="false"/>
     </f:entry>
-    <f:entry title="CI Build Phrases" field="ciBuildPhrases">
+    <f:entry title="Phrase to request a build" field="ciBuildPhrases">
       <f:textbox default="test this please"/>
     </f:entry>
   </f:advanced>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
@@ -6,7 +6,7 @@
   <f:entry title="Stash URL" field="stashHost">
       <f:textbox />
   </f:entry>
-  <f:entry title="Stash Credentials (username/password)" field="credentialsId">
+  <f:entry title="Stash credentials (username/password)" field="credentialsId">
     <c:select />
   </f:entry>
   <f:entry title="Project" field="projectCode">

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-cancelOutdatedJobsEnabled.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-cancelOutdatedJobsEnabled.html
@@ -1,0 +1,4 @@
+<div>
+    When starting the PR build, cancel all jobs in the queue for the
+    same PR. Also abort currently running jobs for that PR.
+</div>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-checkDestinationCommit.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-checkDestinationCommit.html
@@ -1,0 +1,4 @@
+<div>
+    Start the build if the destination commit has changed, i.e. some changes
+    have been made on the target branch.
+</div>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-checkMergeable.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-checkMergeable.html
@@ -1,0 +1,6 @@
+<div>
+    Build the PR only if Stash considers it mergeable. Please note that
+    if the PR doesn't have the required number of approvals, it would be
+    considered non-mergeable and would not be tested when this option is
+    enabled.
+</div>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-checkNotConflicted.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-checkNotConflicted.html
@@ -1,0 +1,7 @@
+<div>
+    Don't build the PR if Stash reports it to be in the <em>conflict</em>
+    state. This <strong>must</strong> be used if using the <em>merge</em>
+    refspec. Stash 2.9+ doesn't provide the <em>merge</em> refspec for
+    conflicted PRs, so Jenkins could end up testing an older version of
+    the PR.
+</div>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-ciBuildPhrases.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-ciBuildPhrases.html
@@ -4,7 +4,7 @@
 
     The phrase should be a substring of the comment. The case is ignored.
     For instance, "Test this please, Jenkins!" would match the default
-    setting.
+    setting.<br/>
 
     Default: <em>test this please</em>
 </div>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-ciBuildPhrases.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-ciBuildPhrases.html
@@ -2,5 +2,9 @@
     Build the PR if the specified phrase has been posted as a PR comment
     in Stash, even if the PR has not changed.<br/>
 
+    The phrase should be a substring of the comment. The case is ignored.
+    For instance, "Test this please, Jenkins!" would match the default
+    setting.
+
     Default: <em>test this please</em>
 </div>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-ciBuildPhrases.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-ciBuildPhrases.html
@@ -1,0 +1,6 @@
+<div>
+    Build the PR if the specified phrase has been posted as a PR comment
+    in Stash, even if the PR has not changed.<br/>
+
+    Default: <em>test this please</em>
+</div>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-ciSkipPhrases.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-ciSkipPhrases.html
@@ -1,0 +1,6 @@
+<div>
+    Do not build the PR if the specified phrase has been posted in a PR
+    comment. Multiple comma-separated phrases are supported.<br/>
+
+    Default: <em>NO TEST</em>
+</div>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-credentialsId.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-credentialsId.html
@@ -1,0 +1,4 @@
+<div>
+    Credentials for accessing the Stash REST API host.
+    This is <strong>not</strong> an ssh key.
+</div>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-cron.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-cron.html
@@ -1,0 +1,5 @@
+<div>
+    Specify how often Stash REST API should be polled for pull requests.
+    For instance, <code>H/2 * * * *</code> would make Jenkins poll Stash
+    every 2 minutes.
+</div>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-deletePreviousBuildFinishComments.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-deletePreviousBuildFinishComments.html
@@ -1,0 +1,3 @@
+<div>
+    Delete old comments about finished PR builds when starting a new build.
+</div>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-ignoreSsl.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-ignoreSsl.html
@@ -1,0 +1,4 @@
+<div>
+    Allow invalid or unverifiable (e.g. self-signed) https certificates
+    for Stash REST API access.
+</div>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-mergeOnSuccess.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-mergeOnSuccess.html
@@ -1,7 +1,4 @@
 <div>
-    Tell Stash to merge the PR if the test job has been successful.<br/>
-
-    <strong>NOTE:</strong> Don't use this option with multi-configuration
-    (matrix) jobs, as it would cause the PR to be merged even if just one
-    configuration passes testing while all others fail.
+    Tell Stash to merge the PR automatically if the test job has been
+    successful.
 </div>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-mergeOnSuccess.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-mergeOnSuccess.html
@@ -1,4 +1,4 @@
 <div>
-    Tell Stash to merge the PR automatically if the test job has been
+    Tell Stash to merge the PR automatically if the build job has been
     successful.
 </div>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-mergeOnSuccess.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-mergeOnSuccess.html
@@ -1,0 +1,7 @@
+<div>
+    Tell Stash to merge the PR if the test job has been successful.<br/>
+
+    <strong>NOTE:</strong> Don't use this option with multi-configuration
+    (matrix) jobs, as it would cause the PR to be merged even if just one
+    configuration passes testing while all others fail.
+</div>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-onlyBuildOnComment.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-onlyBuildOnComment.html
@@ -1,5 +1,5 @@
 <div>
-    Only trigger the build when the test phrase has been posted. Don't
+    Only trigger the build when the build phrase has been posted. Don't
     trigger the build for other reasons, e.g. when a new PR is found or
     when a PR is updated.
 </div>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-onlyBuildOnComment.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-onlyBuildOnComment.html
@@ -1,0 +1,5 @@
+<div>
+    Only trigger the build when the test phrase has been posted. Don't
+    trigger the build for other reasons, e.g. when a new PR is found or
+    when a PR is updated.
+</div>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-projectCode.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-projectCode.html
@@ -1,3 +1,4 @@
 <div>
-    Project key (abbreviated name) in Stash, e.g. <em>PRJ</em>
+    Project key (abbreviated name) in Stash, e.g. <em>PRJ</em> or
+    <em>~username</em>
 </div>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-projectCode.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-projectCode.html
@@ -1,0 +1,3 @@
+<div>
+    Project key (abbreviated name) in Stash, e.g. <em>PRJ</em>
+</div>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-repositoryName.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-repositoryName.html
@@ -1,0 +1,3 @@
+<div>
+    Name of the repository to be monitored in Stash
+</div>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-stashHost.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-stashHost.html
@@ -1,0 +1,4 @@
+<div>
+    The base URL of the Stash server REST API.
+    This is <strong>not</strong> a URL for git.
+</div>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-stashHost.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-stashHost.html
@@ -1,5 +1,6 @@
 <div>
-    The http or https URL of the Stash server REST API.
+    The http or https URL of the Stash server REST API.<br/>
+
     <strong>NOTE:</strong> This is <em>not</em> the git clone URL.<br/>
 
     Example: <code>https://stash.example.com/</code>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-stashHost.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-stashHost.html
@@ -1,4 +1,6 @@
 <div>
-    The base URL of the Stash server REST API.
-    This is <strong>not</strong> a URL for git.
+    The http or https URL of the Stash server REST API.
+    <strong>NOTE:</strong> This is <em>not</em> the git clone URL.<br/>
+
+    Example: <code>https://stash.example.com/</code>
 </div>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-targetBranchesToBuild.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-targetBranchesToBuild.html
@@ -1,0 +1,5 @@
+<div>
+    Only consider pull requests targeting specific branches. If empty, all
+    branches are considered. Use a comma separated list of regular expressions,
+    e.g. <code>master,release/.*</code>
+</div>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help.html
@@ -1,0 +1,6 @@
+<div>
+    Configure Jenkins to check a repository in Stash (Bitbucket Server) for
+    pull requests and trigger a build when a new pull request is posted or an
+    existing pull request is updated. The build result is posted to Stash as
+    a comment.
+</div>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashPostBuildComment/help.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashPostBuildComment/help.html
@@ -1,0 +1,3 @@
+<div>
+    Customize Stash comments posted by the Stash pull request builder.
+</div>


### PR DESCRIPTION
I don't consider it a release blocker, but I think it's a matter of courtesy to the users. I believe users would be more willing to report issues when the observed behavior mismatches the documentation.

The changes include:

* Help files for all UI fields
* Improvements for some labels (consistent capitalization, avoiding abbreviations)
* README.md updated to reflect the updated label names, expanded explanations, uniform formatting.