### PR TITLE
[JENKINS-55853] Fix post build comments for matrix builds

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPostBuildComment.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPostBuildComment.java
@@ -2,23 +2,19 @@ package stashpullrequestbuilder.stashpullrequestbuilder;
 
 import hudson.Extension;
 import hudson.Launcher;
-import hudson.Util;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
-import hudson.model.Result;
+import hudson.model.Describable;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
 import hudson.tasks.Publisher;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
-public class StashPostBuildComment extends Notifier {
-  private static final Logger logger = Logger.getLogger(StashBuildTrigger.class.getName());
+public class StashPostBuildComment extends Notifier implements Describable<Publisher> {
   private String buildSuccessfulComment;
   private String buildFailedComment;
 
@@ -50,18 +46,6 @@ public class StashPostBuildComment extends Notifier {
 
   @Override
   public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
-
-    try {
-      build.addAction(
-          new StashPostBuildCommentAction(
-              Util.fixEmptyAndTrim(build.getEnvironment(listener).expand(buildSuccessfulComment)),
-              Util.fixEmptyAndTrim(build.getEnvironment(listener).expand(buildFailedComment))));
-    } catch (Exception e) {
-      logger.log(Level.SEVERE, "Unable to parse comments", e);
-      listener.finished(Result.FAILURE);
-      return false;
-    }
-
     return true;
   }
 

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPostBuildCommentAction.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPostBuildCommentAction.java
@@ -3,19 +3,13 @@ package stashpullrequestbuilder.stashpullrequestbuilder;
 import hudson.model.InvisibleAction;
 
 public class StashPostBuildCommentAction extends InvisibleAction {
-  private final String buildSuccessfulComment;
-  private final String buildFailedComment;
+  // Recognize deprecated fields so they can be read in from XML, but mark
+  // them transient so they are not saved.
+  @Deprecated
+  @SuppressWarnings("unused")
+  private final transient String buildSuccessfulComment = null;
 
-  public StashPostBuildCommentAction(String buildSuccessfulComment, String buildFailedComment) {
-    this.buildSuccessfulComment = buildSuccessfulComment;
-    this.buildFailedComment = buildFailedComment;
-  }
-
-  public String getBuildSuccessfulComment() {
-    return this.buildSuccessfulComment;
-  }
-
-  public String getBuildFailedComment() {
-    return this.buildFailedComment;
-  }
+  @Deprecated
+  @SuppressWarnings("unused")
+  private final transient String buildFailedComment = null;
 }


### PR DESCRIPTION
```
*  Fix post build comments for matrix builds
   
   Process post build comments in StashBuilds#onCompleted(), which is run in
   the top-level build, unlike StashPostBuildComment#perform() that is run
   in the child builds.
   
   Make StashPostBuildComment implement Describable<Publisher>. Find the
   StashPostBuildComment object in the publisher list of the project.
   If the post build comment cannot be expanded, post it unexpanded with a
   warning.
   
   Keep StashPostBuildCommentAction for backward compatibility.
```