### PR TITLE
[JENKINS-51480] Fixes for environment variables

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashAditionalParameterEnvironmentContributor.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashAditionalParameterEnvironmentContributor.java
@@ -10,46 +10,28 @@ import java.util.*;
 
 @Extension
 public class StashAditionalParameterEnvironmentContributor extends EnvironmentContributor {
-    private static Set<String> params =
-            new HashSet<String>(Arrays.asList("sourceBranch",
-                    "targetBranch",
-                    "sourceRepositoryOwner",
-                    "sourceRepositoryName",
-                    "pullRequestId",
-                    "destinationRepositoryOwner",
-                    "destinationRepositoryName",
-                    "pullRequestTitle",
-                    "sourceCommitHash",
-                    "destinationCommitHash"));
-
     @Override
     public void buildEnvironmentFor(@Nonnull Run r, @Nonnull EnvVars envs, @Nonnull TaskListener listener) throws IOException, InterruptedException {
         StashCause cause = (StashCause) r.getCause(StashCause.class);
         if (cause == null) {
             return;
         }
-        ParametersAction pa = r.getAction(ParametersAction.class);
-        for (String param : params) {
-            addParameter(param, pa, envs);
-        }
+
+        putEnvVar(envs, "sourceBranch", cause.getSourceBranch());
+        putEnvVar(envs, "targetBranch", cause.getTargetBranch());
+        putEnvVar(envs, "sourceRepositoryOwner", cause.getSourceRepositoryOwner());
+        putEnvVar(envs, "sourceRepositoryName", cause.getSourceRepositoryName());
+        putEnvVar(envs, "pullRequestId", cause.getPullRequestId());
+        putEnvVar(envs, "destinationRepositoryOwner", cause.getDestinationRepositoryOwner());
+        putEnvVar(envs, "destinationRepositoryName", cause.getDestinationRepositoryName());
+        putEnvVar(envs, "pullRequestTitle", cause.getPullRequestTitle());
+        putEnvVar(envs, "sourceCommitHash", cause.getSourceCommitHash());
+        putEnvVar(envs, "destinationCommitHash", cause.getDestinationCommitHash());
+
         super.buildEnvironmentFor(r, envs, listener);
     }
 
-    private static void addParameter(String key,
-                                     ParametersAction pa,
-                                     EnvVars envs) {
-        ParameterValue pv = pa.getParameter(key);
-        if (pv == null || !(pv instanceof StringParameterValue)) {
-            return;
-        }
-        StringParameterValue value = (StringParameterValue) pa.getParameter(key);
-        envs.put(key, getString(value.value, ""));
+    private static void putEnvVar(EnvVars envs, String key, String value) {
+        envs.put(key, Objects.toString(value, ""));
     }
-
-    private static String getString(String actual,
-                                    String d) {
-        return actual == null ? d : actual;
-    }
-
-
 }

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashAditionalParameterEnvironmentContributor.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashAditionalParameterEnvironmentContributor.java
@@ -12,21 +12,24 @@ import java.util.*;
 public class StashAditionalParameterEnvironmentContributor extends EnvironmentContributor {
     @Override
     public void buildEnvironmentFor(@Nonnull Run r, @Nonnull EnvVars envs, @Nonnull TaskListener listener) throws IOException, InterruptedException {
-        StashCause cause = (StashCause) r.getCause(StashCause.class);
-        if (cause == null) {
-            return;
-        }
+        if (r instanceof AbstractBuild) {
+            AbstractBuild build = (AbstractBuild) r;
+            AbstractBuild rootBuild = build.getRootBuild();
 
-        putEnvVar(envs, "sourceBranch", cause.getSourceBranch());
-        putEnvVar(envs, "targetBranch", cause.getTargetBranch());
-        putEnvVar(envs, "sourceRepositoryOwner", cause.getSourceRepositoryOwner());
-        putEnvVar(envs, "sourceRepositoryName", cause.getSourceRepositoryName());
-        putEnvVar(envs, "pullRequestId", cause.getPullRequestId());
-        putEnvVar(envs, "destinationRepositoryOwner", cause.getDestinationRepositoryOwner());
-        putEnvVar(envs, "destinationRepositoryName", cause.getDestinationRepositoryName());
-        putEnvVar(envs, "pullRequestTitle", cause.getPullRequestTitle());
-        putEnvVar(envs, "sourceCommitHash", cause.getSourceCommitHash());
-        putEnvVar(envs, "destinationCommitHash", cause.getDestinationCommitHash());
+            StashCause cause = (StashCause) rootBuild.getCause(StashCause.class);
+            if (cause != null) {
+                putEnvVar(envs, "sourceBranch", cause.getSourceBranch());
+                putEnvVar(envs, "targetBranch", cause.getTargetBranch());
+                putEnvVar(envs, "sourceRepositoryOwner", cause.getSourceRepositoryOwner());
+                putEnvVar(envs, "sourceRepositoryName", cause.getSourceRepositoryName());
+                putEnvVar(envs, "pullRequestId", cause.getPullRequestId());
+                putEnvVar(envs, "destinationRepositoryOwner", cause.getDestinationRepositoryOwner());
+                putEnvVar(envs, "destinationRepositoryName", cause.getDestinationRepositoryName());
+                putEnvVar(envs, "pullRequestTitle", cause.getPullRequestTitle());
+                putEnvVar(envs, "sourceCommitHash", cause.getSourceCommitHash());
+                putEnvVar(envs, "destinationCommitHash", cause.getDestinationCommitHash());
+            }
+        }
 
         super.buildEnvironmentFor(r, envs, listener);
     }

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -223,16 +223,6 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
     public QueueTaskFuture<?> startJob(StashCause cause) {
         List<ParameterValue> values = getDefaultParameters();
-        values.add(new StringParameterValue("sourceBranch", cause.getSourceBranch()));
-        values.add(new StringParameterValue("targetBranch", cause.getTargetBranch()));
-        values.add(new StringParameterValue("sourceRepositoryOwner", cause.getSourceRepositoryOwner()));
-        values.add(new StringParameterValue("sourceRepositoryName", cause.getSourceRepositoryName()));
-        values.add(new StringParameterValue("pullRequestId", cause.getPullRequestId()));
-        values.add(new StringParameterValue("destinationRepositoryOwner", cause.getDestinationRepositoryOwner()));
-        values.add(new StringParameterValue("destinationRepositoryName", cause.getDestinationRepositoryName()));
-        values.add(new StringParameterValue("pullRequestTitle", cause.getPullRequestTitle()));
-        values.add(new StringParameterValue("sourceCommitHash", cause.getSourceCommitHash()));
-        values.add(new StringParameterValue("destinationCommitHash", cause.getDestinationCommitHash()));
 
         Map<String, String> additionalParameters = cause.getAdditionalParameters();
         if(additionalParameters != null){


### PR DESCRIPTION
Edited: no longer work in progress, should be good to commit.

First commit:
* There are no more warnings about environment variables from the freestyle projects (JENKINS-51480).

Second commit:
* Child jobs in mutliconfiguration projects get the environment variables without any special settings.

Not addressed by this commit, will be part of the JENKINS-56012 work:
* Mutliconfiguration projects still report a lot of warnings about parameters if configurations are tested subsequently. That may actually be a Jenkins bug. Something gets reused, and the warnings are actually incorrect, as the project does define those variables. The amount of the warnings (15 per variable per build) suggests that they come non-build runs (e.g. git invocations).