### PR TITLE
[JENKINS-56337] StashBuildTrigger: Respect the quiet period

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -230,7 +230,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
       abortRunningJobsThatMatch(cause);
     }
 
-    return this.job.scheduleBuild2(0, cause, new ParametersAction(values));
+    return job.scheduleBuild2(job.getQuietPeriod(), cause, new ParametersAction(values));
   }
 
   private void cancelPreviousJobsInQueueThatMatch(@Nonnull StashCause stashCause) {


### PR DESCRIPTION
```
*  StashBuildTrigger: Respect the quiet period set for the job
   
   There is no good reason to skip the quiet period when the action is taken
   during non-interactive operation.
```