### PR TITLE
Skip default parameters that are null

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -280,7 +280,13 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         this.job.getProperty(ParametersDefinitionProperty.class);
     if (definitionProperty != null) {
       for (ParameterDefinition definition : definitionProperty.getParameterDefinitions()) {
-        values.add(definition.getDefaultParameterValue());
+        ParameterValue defaultValue = definition.getDefaultParameterValue();
+        if (defaultValue == null) {
+          // Can happen for File parameter and Run parameter
+          logger.fine(format("No default value for the parameter '%s'.", definition.getName()));
+        } else {
+          values.add(defaultValue);
+        }
       }
     }
     return values;


### PR DESCRIPTION
```
*  Skip default parameters that are null
   
   Some parameters (e.g. file parameters and run parameters) can only be
   filled by the user if the job is run interactively by "Build with
   parameters". When the job is triggered by a pull request, those
   parameters are set to null.
```
Inspired by https://github.com/jenkinsci/ghprb-plugin/pull/715/files by @MartinCon