### PR TITLE
[JENKINS-56349] Protect against null pointer exception

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -30,6 +30,7 @@ import hudson.util.ListBoxModel;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
@@ -195,11 +196,9 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
   @Override
   public void start(AbstractProject<?, ?> project, boolean newInstance) {
     try {
-      this.stashPullRequestsBuilder = StashPullRequestsBuilder.getBuilder();
-      this.stashPullRequestsBuilder.setProject(project);
-      this.stashPullRequestsBuilder.setTrigger(this);
-      this.stashPullRequestsBuilder.setupBuilder();
-    } catch (IllegalStateException e) {
+      Objects.requireNonNull(project, "project is null");
+      this.stashPullRequestsBuilder = new StashPullRequestsBuilder(project, this);
+    } catch (NullPointerException e) {
       logger.log(Level.SEVERE, "Can't start trigger", e);
       return;
     }

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -287,17 +287,24 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
   @Override
   public void run() {
-    if (this.getBuilder().getProject().isDisabled()) {
-      logger.info(format("Build Skip (%s).", getBuilder().getProject().getName()));
-    } else {
-      logger.info(format("Build started (%s).", getBuilder().getProject().getName()));
-      this.stashPullRequestsBuilder.run();
+    if (stashPullRequestsBuilder == null) {
+      logger.info("Not ready to run.");
+      return;
     }
-    this.getDescriptor().save();
+
+    AbstractProject project = stashPullRequestsBuilder.getProject();
+    if (project.isDisabled()) {
+      logger.fine(format("Project disabled, skipping build (%s).", project.getName()));
+      return;
+    }
+
+    stashPullRequestsBuilder.run();
+    getDescriptor().save();
   }
 
   @Override
   public void stop() {
+    stashPullRequestsBuilder = null;
     super.stop();
   }
 

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPullRequestsBuilder.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPullRequestsBuilder.java
@@ -5,6 +5,7 @@ import static java.lang.String.format;
 import hudson.model.AbstractProject;
 import java.util.Collection;
 import java.util.logging.Logger;
+import javax.annotation.Nonnull;
 import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashPullRequestResponseValue;
 
 /** Created by Nathan McCarthy */
@@ -15,12 +16,12 @@ public class StashPullRequestsBuilder {
   private StashRepository repository;
   private StashBuilds builds;
 
-  public static StashPullRequestsBuilder getBuilder() {
-    return new StashPullRequestsBuilder();
-  }
-
-  public void stop() {
-    // TODO?
+  public StashPullRequestsBuilder(
+      @Nonnull AbstractProject project, @Nonnull StashBuildTrigger trigger) {
+    this.project = project;
+    this.trigger = trigger;
+    this.repository = new StashRepository(trigger.getProjectPath(), this);
+    this.builds = new StashBuilds(trigger, repository);
   }
 
   public void run() {
@@ -29,23 +30,6 @@ public class StashPullRequestsBuilder {
     Collection<StashPullRequestResponseValue> targetPullRequests =
         this.repository.getTargetPullRequests();
     this.repository.addFutureBuildTasks(targetPullRequests);
-  }
-
-  public StashPullRequestsBuilder setupBuilder() {
-    if (this.project == null || this.trigger == null) {
-      throw new IllegalStateException();
-    }
-    this.repository = new StashRepository(this.trigger.getProjectPath(), this);
-    this.builds = new StashBuilds(this.trigger, this.repository);
-    return this;
-  }
-
-  public void setProject(AbstractProject<?, ?> project) {
-    this.project = project;
-  }
-
-  public void setTrigger(StashBuildTrigger trigger) {
-    this.trigger = trigger;
   }
 
   public AbstractProject<?, ?> getProject() {


### PR DESCRIPTION
```
*  [JENKINS-56349] Make StashPullRequestsBuilder constructor take two arguments
   
   Call that constructor from StashBuildTrigger#start() instead of using
   setters. Check that project is not null before passing it to the
   StashPullRequestsBuilder constructor.
   
   Remove setters from StashPullRequestsBuilder, they are not used anymore.

*  [JENKINS-56349] Protect StashBuildTrigger#run() against crash if called early
   
   Trigger#run() can be called before Trigger#start() according to
   https://javadoc.jenkins.io/hudson/triggers/Trigger.html#run--
   
   Improve the log message if the project is disabled. Lower the level to
   "fine", it should be clear why the disabled project is not building pull
   requests.
   
   Don't log anything when starting the build, the builder logs a similar
   message.
   
   Make stop() set the builder to null to revert the effect of start().
```
Please see:
https://issues.jenkins-ci.org/browse/JENKINS-56349

Comment by Eyal Goren:
https://wiki.jenkins.io/display/JENKINS/Stash+pullrequest+builder+plugin

This is not a fix for pipeline support. This is a fix for a crash found when trying to setup a pipeline.

The first commit fixes the abomination that amounts to constructing an object from outside the class. The second commit adds some defensive measures to `StashBuildTrigger#run()` if it's run too early.