### PR TITLE
pom.xml: Enable all compiler warnings by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,16 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <compilerArgs>
+              <arg>-Xlint:all</arg>
+            </compilerArgs>
+            <showWarnings>true</showWarnings>
+            <showDeprecation>true</showDeprecation>
+          </configuration>
+        </plugin>
+        <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>findbugs-maven-plugin</artifactId>
           <configuration>


### PR DESCRIPTION
That's the maven-compiler-plugin output I'm getting with the change:
```
[INFO] --- maven-compiler-plugin:3.8.0:compile (default-compile) @ stash-pullrequest-builder ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 24 source files to /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/target/classes
[WARNING] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java:[22,30] org.apache.http.params.CoreConnectionPNames in org.apache.http.params has been deprecated
[INFO] stashpullrequestbuilder.stashpullrequestbuilder.StashAditionalParameterEnvironmentContributor indexed under hudson.Extension
[INFO] stashpullrequestbuilder.stashpullrequestbuilder.StashPostBuildComment.DESCRIPTOR indexed under hudson.Extension
[INFO] stashpullrequestbuilder.stashpullrequestbuilder.StashBuildListener indexed under hudson.Extension
[INFO] stashpullrequestbuilder.stashpullrequestbuilder.StashBuildTrigger.descriptor indexed under hudson.Extension
[WARNING] No processor claimed any of these annotations: org.codehaus.jackson.annotate.JsonIgnoreProperties,org.kohsuke.stapler.DataBoundConstructor,org.kohsuke.stapler.QueryParameter,org.kohsuke.stapler.DataBoundSetter,org.kohsuke.stapler.export.ExportedBean,org.kohsuke.stapler.AncestorInPath,org.codehaus.jackson.annotate.JsonIgnore,hudson.Extension,org.codehaus.jackson.annotate.JsonProperty,javax.annotation.Nonnull,edu.umd.cs.findbugs.annotations.SuppressFBWarnings,javax.annotation.Nullable
[WARNING] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java:[22,30] org.apache.http.params.CoreConnectionPNames in org.apache.http.params has been deprecated
[WARNING] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java:[22,30] org.apache.http.params.CoreConnectionPNames in org.apache.http.params has been deprecated
[WARNING] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java:[215,48] found raw type: hudson.model.AbstractProject
  missing type arguments for generic class hudson.model.AbstractProject<P,R>
[WARNING] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java:[216,9] found raw type: hudson.triggers.Trigger
  missing type arguments for generic class hudson.triggers.Trigger<J>
[WARNING] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java:[216,45] unchecked call to <T>getTrigger(java.lang.Class<T>) as a member of the raw type hudson.model.AbstractProject
[WARNING] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java:[258,17] found raw type: hudson.model.Build
  missing type arguments for generic class hudson.model.Build<P,B>
[WARNING] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java:[259,73] unchecked method invocation: method hasCauseFromTheSamePullRequest in class stashpullrequestbuilder.stashpullrequestbuilder.StashBuildTrigger is applied to given types
  required: java.util.List<hudson.model.Cause>,stashpullrequestbuilder.stashpullrequestbuilder.StashCause
  found: java.util.List,stashpullrequestbuilder.stashpullrequestbuilder.StashCause
[WARNING] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java:[259,89] unchecked conversion
  required: java.util.List<hudson.model.Cause>
  found:    java.util.List
[WARNING] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java:[98,27] unchecked conversion
  required: java.util.List<stashpullrequestbuilder.stashpullrequestbuilder.stash.StashPullRequestResponseValue>
  found:    java.util.List
[WARNING] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java:[123,27] unchecked conversion
  required: java.util.List<stashpullrequestbuilder.stashpullrequestbuilder.stash.StashPullRequestComment>
  found:    java.util.List
[WARNING] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java:[180,33] org.apache.http.params.CoreConnectionPNames in org.apache.http.params has been deprecated
[WARNING] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java:[182,33] org.apache.http.params.CoreConnectionPNames in org.apache.http.params has been deprecated
[WARNING] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java:[170,11] unreachable catch clause
  thrown type java.io.UnsupportedEncodingException has already been caught
[WARNING] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java:[26,32] found raw type: hudson.model.AbstractBuild
  missing type arguments for generic class hudson.model.AbstractBuild<P,R>
[WARNING] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java:[27,37] unchecked call to <T>getCause(java.lang.Class<T>) as a member of the raw type hudson.model.Run
[WARNING] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java:[34,27] found raw type: hudson.model.AbstractBuild
  missing type arguments for generic class hudson.model.AbstractBuild<P,R>
[WARNING] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java:[46,29] found raw type: hudson.model.AbstractBuild
  missing type arguments for generic class hudson.model.AbstractBuild<P,R>
[WARNING] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashAditionalParameterEnvironmentContributor.java:[17,46] found raw type: hudson.model.Run
  missing type arguments for generic class hudson.model.Run<JobT,RunT>
[WARNING] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashAditionalParameterEnvironmentContributor.java:[19,13] found raw type: hudson.model.AbstractBuild
  missing type arguments for generic class hudson.model.AbstractBuild<P,R>
[WARNING] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashAditionalParameterEnvironmentContributor.java:[20,13] found raw type: hudson.model.AbstractBuild
  missing type arguments for generic class hudson.model.AbstractBuild<P,R>
[WARNING] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashAditionalParameterEnvironmentContributor.java:[22,63] unchecked call to <T>getCause(java.lang.Class<T>) as a member of the raw type hudson.model.Run
[WARNING] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPostBuildComment.java:[89,53] found raw type: hudson.model.AbstractProject
  missing type arguments for generic class hudson.model.AbstractProject<P,R>
[WARNING] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildListener.java:[15,53] found raw type: hudson.model.AbstractBuild
  missing type arguments for generic class hudson.model.AbstractBuild<P,R>
[WARNING] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildListener.java:[19,27] found raw type: hudson.model.AbstractBuild
  missing type arguments for generic class hudson.model.AbstractBuild<P,R>
[WARNING] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildListener.java:[29,29] found raw type: hudson.model.AbstractBuild
  missing type arguments for generic class hudson.model.AbstractBuild<P,R>
```
That's what it was before:
```
[INFO] --- maven-compiler-plugin:3.6.1:compile (default-compile) @ stash-pullrequest-builder ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 24 source files to /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/target/classes
[INFO] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java: /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java uses or overrides a deprecated API.
[INFO] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java: Recompile with -Xlint:deprecation for details.
[INFO] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java: Some input files use unchecked or unsafe operations.
[INFO] /home/roskinp/src/jenkins/plugins/stash-pullrequest-builder-plugin/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java: Recompile with -Xlint:unchecked for details.
```
The later is not actionable. I don't know if we can fix all those warnings, but it's helpful to see them during development to avoid introducing more flaky code.