### PR TITLE
StashApiClient: Return Collections.emptyList(), not Collections.EMPTY_LIST

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
@@ -95,7 +95,7 @@ public class StashApiClient {
         } catch (IOException e) {
             logger.log(Level.WARNING, "invalid pull request response.", e);
         }
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     public List<StashPullRequestComment> getPullRequestComments(String projectCode, String commentRepositoryName,
@@ -120,7 +120,7 @@ public class StashApiClient {
         } catch (Exception e) {
             logger.log(Level.WARNING, "invalid pull request response.", e);
         }
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     public void deletePullRequestComment(String pullRequestId, String commentId) {


### PR DESCRIPTION
Collections.emptyList() returns List of the correct type, whereas Collections.EMPTY_LIST returns the raw List type.

That's one of the warnings that can actually be fixed, not suppressed.