### PR TITLE
Add options to set PR to Approved or Needs Work

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Select *Stash Pull Request Builder* then configure:
 - **Phrase to disable builds**: Don't build the PR if the specified phrase has been posted in a PR comment. Default: *NO TEST*
 - **Only build if asked with the build phrase**: Only trigger the build when the build phrase has been posted.
 - **Phrase to request a build**: Force (re-)building the PR if the specified phrase has been posted as a PR comment in Stash. This is useful when a build fails due to circumstances unrelated to the codebase. Starting a build in Jenkins GUI won't work, as the pull request data won't be available. Default: *test this please*
+- **Approve PR on build success**: Marks a PR as Approved when build succeeds.
+- **Mark PR with Needs Work on build failure**: Mark a PR with "Needs Work" when build fails.
 
 ## Building the merge of Source Branch into Target Branch
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,12 @@
       <artifactId>credentials</artifactId>
       <version>2.1.5</version>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.7.22</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -67,6 +67,8 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     private final boolean onlyBuildOnComment;
     private final boolean deletePreviousBuildFinishComments;
     private final boolean cancelOutdatedJobsEnabled;
+    private final boolean approveOnBuildSuccessful;
+    private final boolean needsWorkOnBuildFailure;
 
     private boolean checkProbeMergeStatus;
 
@@ -93,7 +95,9 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
             String ciBuildPhrases,
             boolean deletePreviousBuildFinishComments,
             String targetBranchesToBuild,
-            boolean cancelOutdatedJobsEnabled
+            boolean cancelOutdatedJobsEnabled,
+            boolean approveOnBuildSuccessful,
+            boolean needsWorkOnBuildFailure
     ) throws ANTLRException {
         super(cron);
         this.projectPath = projectPath;
@@ -113,6 +117,8 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         this.onlyBuildOnComment = onlyBuildOnComment;
         this.deletePreviousBuildFinishComments = deletePreviousBuildFinishComments;
         this.targetBranchesToBuild = targetBranchesToBuild;
+        this.approveOnBuildSuccessful = approveOnBuildSuccessful;
+        this.needsWorkOnBuildFailure = needsWorkOnBuildFailure;
     }
 
     @DataBoundSetter
@@ -196,6 +202,14 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
     public boolean isCancelOutdatedJobsEnabled() {
         return cancelOutdatedJobsEnabled;
+    }
+
+    public boolean isApproveOnBuildSuccessful() {
+        return approveOnBuildSuccessful;
+    }
+
+     public boolean isNeedsWorkOnBuildFailure() {
+        return needsWorkOnBuildFailure;
     }
 
     @Override

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
@@ -77,6 +77,16 @@ public class StashBuilds {
                 cause.getDestinationCommitHash(), result, buildUrl,
                 build.getNumber(), additionalComment, duration);
 
+        // Mark PR as Approved or Needs Work
+        StashMarkStatus status = new StashMarkStatus();
+        status.handleStatus(
+                trigger.isApproveOnBuildSuccessful(),
+                trigger.isNeedsWorkOnBuildFailure(),
+                cause.getPullRequestId(),
+                build.getResult(),
+                repository
+        );
+
         //Merge PR
         StashBuildTrigger trig = StashBuildTrigger.getTrigger(build.getProject());
         if(trig.getMergeOnSuccess() && build.getResult() == Result.SUCCESS) {

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashMarkStatus.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashMarkStatus.java
@@ -1,0 +1,18 @@
+package stashpullrequestbuilder.stashpullrequestbuilder;
+
+import hudson.model.Result;
+import hudson.model.Run;
+
+public class StashMarkStatus {
+
+     public void handleStatus(Boolean approveOnBuildSuccessful, Boolean needsWorkOnBuildFailure, String pullRequestId,
+        Result result, StashRepository repository) {
+        if(approveOnBuildSuccessful && result == Result.SUCCESS) {
+            repository.markStatus(pullRequestId, "APPROVED");
+        }
+
+        if(needsWorkOnBuildFailure && result == Result.FAILURE) {
+            repository.markStatus(pullRequestId, "NEEDS_WORK");
+        }
+    }
+}

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -204,6 +204,10 @@ public class StashRepository {
         return this.client.mergePullRequest(pullRequestId, version);
     }
 
+    public void markStatus(String pullRequestId, String status) {
+        this.client.markStatus(pullRequestId, status);
+    }
+
     private Boolean isPullRequestMergable(StashPullRequestResponseValue pullRequest) {
         if (trigger.isCheckMergeable() || trigger.isCheckNotConflicted() || trigger.isCheckProbeMergeStatus()) {
             /* Request PR status from Stash, and consult our configuration

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
@@ -52,5 +52,11 @@
     <f:entry title="Phrase to request a (re-)build" field="ciBuildPhrases">
       <f:textbox default="test this please"/>
     </f:entry>
+    <f:entry title="Approve PR on build success" field="approveOnBuildSuccessful">
+      <f:checkbox default="false"/>
+    </f:entry>
+    <f:entry title="Mark PR with Needs Work on build failure" field="needsWorkOnBuildFailure">
+      <f:checkbox default="false"/>
+    </f:entry>
   </f:advanced>
 </j:jelly>

--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashMarkStatusTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashMarkStatusTest.java
@@ -1,0 +1,55 @@
+package stashpullrequestbuilder.stashpullrequestbuilder;
+
+import hudson.model.Result;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+public class StashMarkStatusTest {
+
+    private StashRepository repository;
+
+    @Before
+    public void setUp() throws Exception {
+        repository = mock(StashRepository.class);
+    }
+
+    @Test
+    public void handleStatus_shouldMarkStatusApprovedOnSuccessfulBuild() throws Exception {
+        StashMarkStatus status = new StashMarkStatus();
+
+        status.handleStatus(true, false, "", Result.SUCCESS, repository);
+
+        verify(repository).markStatus("", "APPROVED");
+    }
+
+    @Test
+    public void handleStatus_shouldMarkStatusNeedsWorkOnFailedBuild() throws Exception {
+        StashMarkStatus status = new StashMarkStatus();
+
+        status.handleStatus(false, true, "", Result.FAILURE, repository);
+
+        verify(repository).markStatus("", "NEEDS_WORK");
+    }
+
+    @Test
+    public void handleStatus_shouldNotMarkStatusApprovedWhenDisabled() throws Exception {
+        StashMarkStatus status = new StashMarkStatus();
+
+        status.handleStatus(false, false, "", Result.SUCCESS, repository);
+
+        verify(repository, never()).markStatus("", "APPROVED");
+    }
+
+    @Test
+    public void handleStatus_shouldNotMarkStatusNeedsWorkWhenDisabled() throws Exception {
+        StashMarkStatus status = new StashMarkStatus();
+
+        status.handleStatus(false, false, "", Result.FAILURE, repository);
+
+        verify(repository, never()).markStatus("", "NEEDS_WORK");
+    }
+
+}


### PR DESCRIPTION
Based on the work of https://github.com/nemccarthy/stash-pullrequest-builder-plugin/pull/123
We already use the original PR of tettaji successfully for the last one and a half years. In our workflow we do not automatically merge by only a successful jenkins build, we also require 2 human peer reviews next to the jenkins (build) review. We merge "manually" when we desire to do so after these 3 approvals.