### PR TITLE
Rename StashAditionalParameterEnvironmentContributor

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildEnvironmentContributor.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildEnvironmentContributor.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 
 @Extension
-public class StashAditionalParameterEnvironmentContributor extends EnvironmentContributor {
+public class StashBuildEnvironmentContributor extends EnvironmentContributor {
   @Override
   public void buildEnvironmentFor(
       @Nonnull Run r, @Nonnull EnvVars envs, @Nonnull TaskListener listener)


### PR DESCRIPTION
```
*  Rename StashAditionalParameterEnvironmentContributor
   
   Not only did the old class name have a typo, a "contributor" is already
   implied to provide something additional.
   
   Also remove a reference to parameters, which are not used in that code
   anymore.
```