### PR TITLE
Use logger names automatically derived from the containing class names

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildListener.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildListener.java
@@ -4,13 +4,15 @@ import hudson.Extension;
 import hudson.model.AbstractBuild;
 import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
+import java.lang.invoke.MethodHandles;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 
 /** Created by Nathan McCarthy */
 @Extension
 public class StashBuildListener extends RunListener<AbstractBuild> {
-  private static final Logger logger = Logger.getLogger(StashBuildTrigger.class.getName());
+  private static final Logger logger =
+      Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
 
   @Override
   public void onStarted(AbstractBuild abstractBuild, TaskListener listener) {

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -27,6 +27,7 @@ import hudson.security.ACL;
 import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
 import hudson.util.ListBoxModel;
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -47,7 +48,8 @@ import org.kohsuke.stapler.StaplerRequest;
 /** Created by Nathan McCarthy */
 @SuppressFBWarnings({"WMI_WRONG_MAP_ITERATOR", "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"})
 public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
-  private static final Logger logger = Logger.getLogger(StashBuildTrigger.class.getName());
+  private static final Logger logger =
+      Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
   private final String projectPath;
   private final String cron;
   private final String stashHost;

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
@@ -94,8 +94,7 @@ public class StashBuilds {
         duration);
 
     // Merge PR
-    StashBuildTrigger trig = StashBuildTrigger.getTrigger(build.getProject());
-    if (trig.getMergeOnSuccess() && build.getResult() == Result.SUCCESS) {
+    if (trigger.getMergeOnSuccess() && build.getResult() == Result.SUCCESS) {
       boolean mergeStat =
           repository.mergePullRequest(cause.getPullRequestId(), cause.getPullRequestVersion());
       if (mergeStat == true) {

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuilds.java
@@ -6,13 +6,15 @@ import hudson.model.Cause;
 import hudson.model.Result;
 import hudson.model.TaskListener;
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.JenkinsLocationConfiguration;
 
 /** Created by Nathan McCarthy */
 public class StashBuilds {
-  private static final Logger logger = Logger.getLogger(StashBuilds.class.getName());
+  private static final Logger logger =
+      Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
   private StashBuildTrigger trigger;
   private StashRepository repository;
 

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPullRequestsBuilder.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPullRequestsBuilder.java
@@ -3,6 +3,7 @@ package stashpullrequestbuilder.stashpullrequestbuilder;
 import static java.lang.String.format;
 
 import hudson.model.AbstractProject;
+import java.lang.invoke.MethodHandles;
 import java.util.Collection;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
@@ -10,7 +11,8 @@ import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashPullRequestRes
 
 /** Created by Nathan McCarthy */
 public class StashPullRequestsBuilder {
-  private static final Logger logger = Logger.getLogger(StashBuildTrigger.class.getName());
+  private static final Logger logger =
+      Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
   private AbstractProject<?, ?> project;
   private StashBuildTrigger trigger;
   private StashRepository repository;

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -4,6 +4,7 @@ import static java.lang.String.format;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.Result;
+import java.lang.invoke.MethodHandles;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -23,7 +24,8 @@ import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashPullRequestRes
 /** Created by Nathan McCarthy */
 @SuppressFBWarnings("WMI_WRONG_MAP_ITERATOR")
 public class StashRepository {
-  private static final Logger logger = Logger.getLogger(StashRepository.class.getName());
+  private static final Logger logger =
+      Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
   public static final String BUILD_START_MARKER = "[*BuildStarted* **%s**] %s into %s";
   public static final String BUILD_FINISH_MARKER = "[*BuildFinished* **%s**] %s into %s";
 

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
+import java.lang.invoke.MethodHandles;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
@@ -53,7 +54,8 @@ public class StashApiClient {
   private static final int HTTP_CONNECTION_TIMEOUT_SECONDS = 15;
   private static final int HTTP_SOCKET_TIMEOUT_SECONDS = 15;
 
-  private static final Logger logger = Logger.getLogger(StashApiClient.class.getName());
+  private static final Logger logger =
+      Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
   private static final ObjectMapper mapper = new ObjectMapper();
 
   private String apiBaseUrl;


### PR DESCRIPTION
```
*  Use logger names automatically derived from the containing class names
   
   StashBuildListener and StashPullRequestsBuilder were using
   "StashBuildTrigger" instead of their own names.
   
   Co-developed-by: Anders Hammar <anders@hammar.net>
   Co-developed-by: jakub-bochenski <kuba.bochenski@gmail.com>
```
This is a superset of #45 based on top of the current master branch. All logger names are generated automatically using exactly the same code.