### PR TITLE
Iterate over map entries more efficiently

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -46,7 +46,7 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
 /** Created by Nathan McCarthy */
-@SuppressFBWarnings({"WMI_WRONG_MAP_ITERATOR", "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"})
+@SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
 public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
   private static final Logger logger =
       Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
@@ -220,8 +220,8 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
     Map<String, String> additionalParameters = cause.getAdditionalParameters();
     if (additionalParameters != null) {
-      for (String parameter : additionalParameters.keySet()) {
-        values.add(new StringParameterValue(parameter, additionalParameters.get(parameter)));
+      for (Map.Entry<String, String> parameter : additionalParameters.entrySet()) {
+        values.add(new StringParameterValue(parameter.getKey(), parameter.getValue()));
       }
     }
 

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -2,7 +2,6 @@ package stashpullrequestbuilder.stashpullrequestbuilder;
 
 import static java.lang.String.format;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.Result;
 import java.lang.invoke.MethodHandles;
 import java.util.AbstractMap;
@@ -22,7 +21,6 @@ import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashPullRequestRes
 import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashPullRequestResponseValueRepository;
 
 /** Created by Nathan McCarthy */
-@SuppressFBWarnings("WMI_WRONG_MAP_ITERATOR")
 public class StashRepository {
   private static final Logger logger =
       Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
@@ -144,8 +142,8 @@ public class StashRepository {
         }
 
         Map<String, String> parameters = getParametersFromContent(content);
-        for (String key : parameters.keySet()) {
-          result.put(key, parameters.get(key));
+        for (Map.Entry<String, String> parameter : parameters.entrySet()) {
+          result.put(parameter.getKey(), parameter.getValue());
         }
       }
       return result;


### PR DESCRIPTION
```
*  Iterate over map entries more efficiently
   
   Use iteration over key-value pairs, not over keys. The later is less
   efficient, as it needs to construct a temporary Set of keys.
   
   Remove attributes to suppress corresponding FindBugs issues.
```