### PR TITLE
[JENKINS-41771] Disable serialization for StashPostBuildComment

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPostBuildComment.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPostBuildComment.java
@@ -24,8 +24,9 @@ public class StashPostBuildComment extends Notifier implements Describable<Publi
     this.buildFailedComment = buildFailedComment;
   }
 
+  @Override
   public BuildStepMonitor getRequiredMonitorService() {
-    return BuildStepMonitor.BUILD;
+    return BuildStepMonitor.NONE;
   }
 
   public String getBuildSuccessfulComment() {


### PR DESCRIPTION
```
*  [JENKINS-41771] Disable serialization for StashPostBuildComment
   
   StashPostBuildComment#perform() doesn't do anything that would require
   serialization.
```