### PR TITLE
Pipeline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,18 @@ These comments can contain environment variables that will be translated when po
 
 This feature can be used to post for instance a URL to the deployed application or code coverage at a successful build and why the build failed like what tests that did not pass.
 
+## Pipeline support
+
+Support for Jenkins pipelines is currently experimental. To enable it, go to *Manage Jenkins*, then *Configure System* and check for *Enable Pipeline Support*.
+
+The configuration is the same as for other projects, but it is not currently possible to customize the comments posted to the Bitbucket Server after the job completion.
+
+Stash Pull Request Builder Plugin could serve as a stepping stone to a more advanced setup using Bitbucket Branch Source Plugin. Unlike the later, this plugin supports inline Groovy scripts for pipeline configuration, which may be handy while figuring out the optimal configuration for the build. Once that configuration is established, it can be added to the sources as `Jenkinsfile`.
+
+Stash Pull Request Builder Plugin makes conversion to pipelines easier the users, as it behaves the same way as before, it just triggers a pipeline project instead of a freestyle project. This plugin works with pull requests only and relies on comments for deciding when and what to build. It would not scan the git repository for all branches and build them all. It will never build a branch before a pull request is created from it.
+
+To use Stash Pull Request Builder Plugin from Jenkinsfile, make sure to define it in properties. Otherwise, the trigger will be disabled after the the job runs. To find the exact syntax, open the Pipeline Syntax link and select "properties" as the Sample Step. Set up the trigger in the GUI and click on "Generate Pipeline Script".
+
 ## Copyright
 
 Copyright © 2015 Nathan McCarthy.

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,12 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <version>2.9</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -267,12 +267,27 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
     public static final String DEFAULT_CI_SKIP_PHRASES = "NO TEST";
     public static final String DEFAULT_CI_BUILD_PHRASES = "test this please";
 
+    private boolean enablePipelineSupport;
+
     public DescriptorImpl() {
       load();
     }
 
+    public boolean getEnablePipelineSupport() {
+      return enablePipelineSupport;
+    }
+
+    @DataBoundSetter
+    public void setEnablePipelineSupport(boolean enablePipelineSupport) {
+      this.enablePipelineSupport = enablePipelineSupport;
+    }
+
     @Override
     public boolean isApplicable(Item item) {
+      if (enablePipelineSupport) {
+        return item instanceof Job && item instanceof ParameterizedJob;
+      }
+
       return item instanceof AbstractProject;
     }
 
@@ -283,6 +298,9 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
 
     @Override
     public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+      enablePipelineSupport = false;
+
+      req.bindJSON(this, json);
       save();
       return super.configure(req, json);
     }

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/global.jelly
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/global.jelly
@@ -1,0 +1,8 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:section title="Stash Pull Request Builder">
+    <f:entry title="Enable pipeline support (experimental)" field="enablePipelineSupport">
+      <f:checkbox />
+    </f:entry>
+  </f:section>
+</j:jelly>

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-enablePipelineSupport.html
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/help-enablePipelineSupport.html
@@ -1,0 +1,11 @@
+<div>
+  <p>
+    Enable support for pipelines. When checked, Stash Pull Request
+    Builder will be available in pipeline based projects. Please note
+    that pipeline support is experimental.
+  </p>
+  <p>
+    Another way to support pipelines with Bitbucket Server is to use
+    Bitbucket Branch Source Plugin.
+  </p>
+</div>

--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTriggerTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTriggerTest.java
@@ -3,13 +3,25 @@ package stashpullrequestbuilder.stashpullrequestbuilder;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 
 import hudson.model.Descriptor.PropertyType;
+import hudson.model.FreeStyleProject;
 import java.util.Arrays;
+import java.util.Collections;
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import net.sf.json.JSONObject;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.kohsuke.stapler.RequestImpl;
+import org.kohsuke.stapler.Stapler;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.WebApp;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.junit.MockitoRule;
@@ -20,6 +32,65 @@ public class StashBuildTriggerTest {
 
   @Rule public JenkinsRule jenkinsRule = new JenkinsRule();
   @Rule public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+
+  private StaplerRequest makeStaplerRequest() {
+    ServletContext servletContext = mock(ServletContext.class);
+    WebApp webApp = new WebApp(servletContext);
+
+    Stapler stapler = mock(Stapler.class);
+    lenient().when(stapler.getWebApp()).thenReturn(webApp);
+
+    HttpServletRequest servletRequest = mock(HttpServletRequest.class);
+
+    return new RequestImpl(stapler, servletRequest, Collections.emptyList(), null);
+  }
+
+  @Test
+  public void pipeline_jobs_not_supported_by_default() throws Exception {
+    JSONObject json = new JSONObject();
+
+    StaplerRequest staplerRequest = makeStaplerRequest();
+    StashBuildTrigger.DescriptorImpl descriptor = new StashBuildTrigger.DescriptorImpl();
+    descriptor.configure(staplerRequest, json);
+
+    FreeStyleProject project = jenkinsRule.createFreeStyleProject();
+    assertThat(descriptor.isApplicable(project), is(true));
+
+    WorkflowJob workflowJob = jenkinsRule.createProject(WorkflowJob.class);
+    assertThat(descriptor.isApplicable(workflowJob), is(false));
+  }
+
+  @Test
+  public void pipeline_jobs_not_supported_when_pipeline_support_disabled() throws Exception {
+    JSONObject json = new JSONObject();
+    json.put("enablePipelineSupport", "false");
+
+    StaplerRequest staplerRequest = makeStaplerRequest();
+    StashBuildTrigger.DescriptorImpl descriptor = new StashBuildTrigger.DescriptorImpl();
+    descriptor.configure(staplerRequest, json);
+
+    FreeStyleProject project = jenkinsRule.createFreeStyleProject();
+    assertThat(descriptor.isApplicable(project), is(true));
+
+    WorkflowJob workflowJob = jenkinsRule.createProject(WorkflowJob.class);
+    assertThat(descriptor.isApplicable(workflowJob), is(false));
+  }
+
+  @Test
+  public void pipeline_jobs_supported_when_pipeline_support_enabled() throws Exception {
+    JSONObject json = new JSONObject();
+    json.put("enablePipelineSupport", "true");
+
+    StaplerRequest staplerRequest = makeStaplerRequest();
+    StashBuildTrigger.DescriptorImpl descriptor = new StashBuildTrigger.DescriptorImpl();
+    descriptor.configure(staplerRequest, json);
+
+    FreeStyleProject project = jenkinsRule.createFreeStyleProject();
+    assertThat(descriptor.isApplicable(project), is(true));
+
+    WorkflowJob workflowJob = jenkinsRule.createProject(WorkflowJob.class);
+    assertThat(descriptor.isApplicable(workflowJob), is(true));
+  }
 
   @Test
   public void check_getters() throws Exception {


### PR DESCRIPTION
_This comment is here to reflect the current state of the PR, it is updated after every push_

This is a rebased commit by @rhencke to support pipelines. It has been successfully tested both with pipelines and with traditional projects (Free Style, Matrix and Maven).

Most changes are already in the master branch. The remaining part is a commit to enable pipeline support in global configuration. That is necessary to make users understand that the support is incomplete and there are other ways to access Bitbucket Server from a pipeline. Also, a section about pipeline has been added to `README.md`.