### PR TITLE
StashBuildTrigger: Only allow jobs derived from AbstractProject

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -339,7 +339,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
     @Override
     public boolean isApplicable(Item item) {
-      return true;
+      return item instanceof AbstractProject;
     }
 
     @Override


### PR DESCRIPTION
This hides Stash Pull Request Builder from the build trigger list in the pipeline configuration. Pipelines are currently unsupported.

Once the pipelines are supported, `isApplicable` will be adjusted to include them.