### PR TITLE
Fix warnings about raw types

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildEnvironmentContributor.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildEnvironmentContributor.java
@@ -17,10 +17,10 @@ public class StashBuildEnvironmentContributor extends EnvironmentContributor {
       @Nonnull Run r, @Nonnull EnvVars envs, @Nonnull TaskListener listener)
       throws IOException, InterruptedException {
     if (r instanceof AbstractBuild) {
-      AbstractBuild build = (AbstractBuild) r;
-      AbstractBuild rootBuild = build.getRootBuild();
+      AbstractBuild<?, ?> build = (AbstractBuild<?, ?>) r;
+      AbstractBuild<?, ?> rootBuild = build.getRootBuild();
 
-      StashCause cause = (StashCause) rootBuild.getCause(StashCause.class);
+      StashCause cause = rootBuild.getCause(StashCause.class);
       if (cause != null) {
         putEnvVar(envs, "sourceBranch", cause.getSourceBranch());
         putEnvVar(envs, "targetBranch", cause.getTargetBranch());

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildListener.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildListener.java
@@ -10,12 +10,12 @@ import javax.annotation.Nonnull;
 
 /** Created by Nathan McCarthy */
 @Extension
-public class StashBuildListener extends RunListener<AbstractBuild> {
+public class StashBuildListener extends RunListener<AbstractBuild<?, ?>> {
   private static final Logger logger =
       Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
 
   @Override
-  public void onStarted(AbstractBuild abstractBuild, TaskListener listener) {
+  public void onStarted(AbstractBuild<?, ?> abstractBuild, TaskListener listener) {
     logger.info("BuildListener onStarted called.");
     StashBuildTrigger trigger = StashBuildTrigger.getTrigger(abstractBuild.getProject());
     if (trigger == null) {
@@ -25,7 +25,7 @@ public class StashBuildListener extends RunListener<AbstractBuild> {
   }
 
   @Override
-  public void onCompleted(AbstractBuild abstractBuild, @Nonnull TaskListener listener) {
+  public void onCompleted(AbstractBuild<?, ?> abstractBuild, @Nonnull TaskListener listener) {
     StashBuildTrigger trigger = StashBuildTrigger.getTrigger(abstractBuild.getProject());
     if (trigger == null) {
       return;

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -207,9 +207,8 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     super.start(project, newInstance);
   }
 
-  public static StashBuildTrigger getTrigger(AbstractProject project) {
-    Trigger trigger = project.getTrigger(StashBuildTrigger.class);
-    return (StashBuildTrigger) trigger;
+  public static StashBuildTrigger getTrigger(AbstractProject<?, ?> project) {
+    return project.getTrigger(StashBuildTrigger.class);
   }
 
   public StashPullRequestsBuilder getBuilder() {
@@ -249,7 +248,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     logger.fine("Looking for running jobs that match PR ID: " + stashCause.getPullRequestId());
     for (Object o : job.getBuilds()) {
       if (o instanceof Build) {
-        Build build = (Build) o;
+        Build<?, ?> build = (Build<?, ?>) o;
         if (build.isBuilding() && hasCauseFromTheSamePullRequest(build.getCauses(), stashCause)) {
           logger.info("Aborting build: " + build + " since PR is outdated");
           build.getExecutor().interrupt(Result.ABORTED);
@@ -300,7 +299,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
       return;
     }
 
-    AbstractProject project = stashPullRequestsBuilder.getProject();
+    AbstractProject<?, ?> project = stashPullRequestsBuilder.getProject();
     if (project.isDisabled()) {
       logger.fine(format("Project disabled, skipping build (%s).", project.getName()));
       return;

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPullRequestsBuilder.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPullRequestsBuilder.java
@@ -19,7 +19,7 @@ public class StashPullRequestsBuilder {
   private StashBuilds builds;
 
   public StashPullRequestsBuilder(
-      @Nonnull AbstractProject project, @Nonnull StashBuildTrigger trigger) {
+      @Nonnull AbstractProject<?, ?> project, @Nonnull StashBuildTrigger trigger) {
     this.project = project;
     this.trigger = trigger;
     this.repository = new StashRepository(trigger.getProjectPath(), this);


### PR DESCRIPTION
```
*  Fix warnings about raw types
   
   Warnings caused by raw types in the Jenkins API are not fixed, as there
   is no way to do it.
   
   Remove casts that are redundant with parameterized types.
```

This would conflict with other PRs, but I'm ready to rebase them quickly if this PR is merged. Let's take care of the warnings and set a higher standard for the new code.