### PR TITLE
pom.xml: Replace unneeded dependency on git with direct dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,13 +77,13 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>git</artifactId>
-      <version>3.0.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
       <version>2.1.5</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.2</version>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
```
*  pom.xml: Replace unneeded dependency on git with direct dependencies
   
   org.apache.http.params.CoreConnectionPNames needs httpclient 4.5.2.
   
   Junit is used in unit tests.
```