### PR TITLE
StashBuildTrigger: Call super.start() first

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -197,6 +197,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
   @Override
   public void start(AbstractProject<?, ?> project, boolean newInstance) {
+    super.start(project, newInstance);
     try {
       Objects.requireNonNull(project, "project is null");
       this.stashPullRequestsBuilder = new StashPullRequestsBuilder(project, this);
@@ -204,7 +205,6 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
       logger.log(Level.SEVERE, "Can't start trigger", e);
       return;
     }
-    super.start(project, newInstance);
   }
 
   public static StashBuildTrigger getTrigger(AbstractProject<?, ?> project) {


### PR DESCRIPTION
```
*  StashBuildTrigger: Call super.start() first
   
   It is safer to let the superclass do its part first. In particular,
   super.start() sets this.job, which should be done before "this" is passed
   to another constructor.
```

The code is very fragile the way it is. I was trying to fix an issue with pipelines, and a seemingly good approach broke everything. The issue is not limited to pipelines. The `StashBuildTrigger` object goes to multiple objects, and it's very easy to use it accidentally before it's ready.

This is a minimal fix that should be easy to review.