### PR TITLE
StashBuildTrigger: Use isBuildable() instead of isDisabled()

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -294,14 +294,13 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
   @Override
   public void run() {
-    if (stashPullRequestsBuilder == null) {
+    if (job == null) {
       logger.info("Not ready to run.");
       return;
     }
 
-    AbstractProject<?, ?> project = stashPullRequestsBuilder.getProject();
-    if (project.isDisabled()) {
-      logger.fine(format("Project disabled, skipping build (%s).", project.getName()));
+    if (!job.isBuildable()) {
+      logger.fine(format("Job is not buildable, skipping build (%s).", job.getName()));
       return;
     }
 


### PR DESCRIPTION
```
*  StashBuildTrigger: Use isBuildable() instead of isDisabled()
   
   There are reasons for a job to be non-buildable other than the project
   being disabled. The Jenkins core uses isBuildable(), not isDisabled()
   when deciding whether to run a job.
   
   Instead of checking that stashPullRequestsBuilder is not null, check that
   this.job is not null. Both are set in start(). Both would be null before
   start() and non-null objects afterwards.
   
   Use this.job instead of stashPullRequestsBuilder.getProject(). Both
   values should be the same, as stashPullRequestsBuilder.getProject()
   returns the value passed to the StashPullRequestsBuilder constructor.
   That is the job argument to start(), which also becomes the value of
   this.job.
```

This little piece of the pipeline PR would be useful whether we support pipelines or not. It reduces interdependence between classes and matches closer to what Jenkins does internally when deciding whether to run a job.