### PR TITLE
StashRepository: Only consider pull requests in the "OPEN" state

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.27.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPullRequestsBuilder.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPullRequestsBuilder.java
@@ -22,7 +22,7 @@ public class StashPullRequestsBuilder {
       @Nonnull AbstractProject<?, ?> project, @Nonnull StashBuildTrigger trigger) {
     this.project = project;
     this.trigger = trigger;
-    this.repository = new StashRepository(this);
+    this.repository = new StashRepository(project, trigger);
     this.builds = new StashBuilds(trigger, repository);
   }
 

--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepositoryTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepositoryTest.java
@@ -1,0 +1,87 @@
+package stashpullrequestbuilder.stashpullrequestbuilder;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import hudson.model.AbstractProject;
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashApiClient;
+import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashPullRequestResponseValue;
+import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashPullRequestResponseValueRepository;
+import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashPullRequestResponseValueRepositoryRepository;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StashRepositoryTest {
+
+  private StashRepository stashRepository;
+
+  @Mock private StashBuildTrigger trigger;
+  @Mock private AbstractProject<?, ?> project;
+  @Mock private StashApiClient stashApiClient;
+  @Mock private StashPullRequestResponseValue pullRequest;
+  @Mock private StashPullRequestResponseValueRepository repository;
+  @Mock private StashPullRequestResponseValueRepositoryRepository repoRepo;
+
+  @Rule public JenkinsRule jenkinsRule = new JenkinsRule();
+
+  @Before
+  public void before() {
+    stashRepository = new StashRepository(project, trigger, stashApiClient);
+  }
+
+  @Test
+  public void getTargetPullRequestsReturnsEmptyListForNoPullRequests() {
+    when(stashApiClient.getPullRequests()).thenReturn(Collections.emptyList());
+
+    assertThat(stashRepository.getTargetPullRequests(), empty());
+
+    verify(stashApiClient, times(1)).getPullRequests();
+  }
+
+  @Test
+  public void getTargetPullRequestsAcceptsOpenPullRequests() {
+    when(stashApiClient.getPullRequests()).thenReturn(Collections.singletonList(pullRequest));
+    when(pullRequest.getState()).thenReturn("OPEN");
+    when(trigger.getCiSkipPhrases()).thenReturn("NO TEST");
+    when(pullRequest.getFromRef()).thenReturn(repository);
+    when(pullRequest.getToRef()).thenReturn(repository);
+    when(repository.getRepository()).thenReturn(repoRepo);
+
+    assertThat(stashRepository.getTargetPullRequests(), contains(pullRequest));
+
+    verify(stashApiClient, times(1)).getPullRequests();
+    verify(pullRequest, times(1)).getTitle();
+  }
+
+  @Test
+  public void getTargetPullRequestsSkipsClosedPullRequests() {
+    when(stashApiClient.getPullRequests()).thenReturn(Collections.singletonList(pullRequest));
+    when(pullRequest.getState()).thenReturn("CLOSED");
+
+    assertThat(stashRepository.getTargetPullRequests(), empty());
+
+    verify(stashApiClient, times(1)).getPullRequests();
+    verify(pullRequest, times(0)).getTitle();
+  }
+
+  @Test
+  public void getTargetPullRequestsSkipsNullStatePullRequests() {
+    when(stashApiClient.getPullRequests()).thenReturn(Collections.singletonList(pullRequest));
+    when(pullRequest.getState()).thenReturn(null);
+
+    assertThat(stashRepository.getTargetPullRequests(), empty());
+
+    verify(stashApiClient, times(1)).getPullRequests();
+    verify(pullRequest, times(0)).getTitle();
+  }
+}


### PR DESCRIPTION
```
*  StashRepository: Only consider pull requests in the "OPEN" state
   
   Pull requests in other states were wrongly considered buildable.
   
   Add a constructor with trigger and client arguments for unit tests. It
   should be possible to make the code friendlier to unit tests in the
   future.
   
   Add unit tests using Mockito and Hamcrest.
```