### PR TITLE
Clean up HTTP client code

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
@@ -51,8 +51,15 @@ import org.codehaus.jackson.node.ObjectNode;
 @SuppressFBWarnings("EQ_DOESNT_OVERRIDE_EQUALS")
 public class StashApiClient {
 
+  // Request timeout: maximum time between sending an HTTP request and receiving
+  // a response to it from the server.
   private static final int HTTP_REQUEST_TIMEOUT_SECONDS = 60;
+
+  // Connection timeout: maximum time for connecting to the HTTP server.
   private static final int HTTP_CONNECTION_TIMEOUT_SECONDS = 15;
+
+  // Socket timeout: maximum period of inactivity between two data packets
+  // arriving to the client once the connection is established.
   private static final int HTTP_SOCKET_TIMEOUT_SECONDS = 30;
 
   private static final Logger logger =
@@ -190,12 +197,8 @@ public class StashApiClient {
   private HttpClient getHttpClient() {
     HttpClient client = new HttpClient();
     HttpParams httpParams = client.getParams();
-    // ConnectionTimeout : This denotes the time elapsed before the connection established or Server
-    // responded to connection request.
     httpParams.setParameter(
         CoreConnectionPNames.CONNECTION_TIMEOUT, HTTP_CONNECTION_TIMEOUT_SECONDS * 1000);
-    // SoTimeout : Maximum period inactivity between two consecutive data packets arriving at client
-    // side after connection is established.
     httpParams.setParameter(CoreConnectionPNames.SO_TIMEOUT, HTTP_SOCKET_TIMEOUT_SECONDS * 1000);
 
     //        if (Jenkins.getInstance() != null) {

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
@@ -142,6 +143,7 @@ public class StashApiClient {
     deleteRequest(path);
   }
 
+  @Nullable
   public StashPullRequestComment postPullRequestComment(String pullRequestId, String comment) {
     String path = pullRequestPath(pullRequestId) + "/comments";
     try {
@@ -156,6 +158,7 @@ public class StashApiClient {
     return null;
   }
 
+  @Nullable
   public StashPullRequestMergeableResponse getPullRequestMergeStatus(String pullRequestId) {
     String path = pullRequestPath(pullRequestId) + "/merge";
     try {

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
@@ -4,7 +4,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
 import java.lang.invoke.MethodHandles;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -157,8 +156,6 @@ public class StashApiClient {
       String response = postRequest(path, comment);
       return parseSingleCommentJson(response);
 
-    } catch (UnsupportedEncodingException e) {
-      e.printStackTrace();
     } catch (IOException e) {
       logger.log(Level.SEVERE, "Failed to post Stash PR comment " + path + " " + e);
     }
@@ -172,8 +169,6 @@ public class StashApiClient {
       String response = getRequest(path);
       return parsePullRequestMergeStatus(response);
 
-    } catch (UnsupportedEncodingException e) {
-      e.printStackTrace();
     } catch (IOException e) {
       logger.log(Level.WARNING, "Failed to get Stash PR Merge Status " + path + " " + e);
     }
@@ -182,16 +177,8 @@ public class StashApiClient {
 
   public boolean mergePullRequest(String pullRequestId, String version) {
     String path = pullRequestPath(pullRequestId) + "/merge?version=" + version;
-    try {
-      String response = postRequest(path, null);
-      return !response.equals(Integer.toString(HttpStatus.SC_CONFLICT));
-
-    } catch (UnsupportedEncodingException e) {
-      e.printStackTrace();
-    } catch (IOException e) {
-      logger.log(Level.SEVERE, "Failed to merge Stash PR " + path + " " + e);
-    }
-    return false;
+    String response = postRequest(path, null);
+    return !response.equals(Integer.toString(HttpStatus.SC_CONFLICT));
   }
 
   private HttpClient getHttpClient() {
@@ -349,7 +336,7 @@ public class StashApiClient {
     logger.log(Level.FINE, "Delete comment {" + path + "} returned result code; " + response);
   }
 
-  private String postRequest(String path, String comment) throws UnsupportedEncodingException {
+  private String postRequest(String path, String comment) {
     logger.log(Level.FINEST, "PR-POST-REQUEST:" + path + " with: " + comment);
     HttpClient client = getHttpClient();
     client.getState().setCredentials(AuthScope.ANY, credentials);

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
@@ -193,12 +193,10 @@ public class StashApiClient {
     // ConnectionTimeout : This denotes the time elapsed before the connection established or Server
     // responded to connection request.
     httpParams.setParameter(
-        CoreConnectionPNames.CONNECTION_TIMEOUT,
-        StashApiClient.HTTP_CONNECTION_TIMEOUT_SECONDS * 1000);
+        CoreConnectionPNames.CONNECTION_TIMEOUT, HTTP_CONNECTION_TIMEOUT_SECONDS * 1000);
     // SoTimeout : Maximum period inactivity between two consecutive data packets arriving at client
     // side after connection is established.
-    httpParams.setParameter(
-        CoreConnectionPNames.SO_TIMEOUT, StashApiClient.HTTP_SOCKET_TIMEOUT_SECONDS * 1000);
+    httpParams.setParameter(CoreConnectionPNames.SO_TIMEOUT, HTTP_SOCKET_TIMEOUT_SECONDS * 1000);
 
     //        if (Jenkins.getInstance() != null) {
     //            ProxyConfiguration proxy = Jenkins.getInstance().proxy;
@@ -275,7 +273,7 @@ public class StashApiClient {
               }.init(client, httpget));
       thread = new Thread(httpTask);
       thread.start();
-      response = httpTask.get((long) StashApiClient.HTTP_REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      response = httpTask.get(HTTP_REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
     } catch (TimeoutException e) {
       e.printStackTrace();
@@ -332,7 +330,7 @@ public class StashApiClient {
               }.init(client, httppost));
       thread = new Thread(httpTask);
       thread.start();
-      res = httpTask.get((long) StashApiClient.HTTP_REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      res = httpTask.get(HTTP_REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
     } catch (TimeoutException e) {
       e.printStackTrace();
@@ -423,7 +421,7 @@ public class StashApiClient {
               }.init(client, httppost));
       thread = new Thread(httpTask);
       thread.start();
-      response = httpTask.get((long) StashApiClient.HTTP_REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      response = httpTask.get(HTTP_REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
     } catch (TimeoutException e) {
       e.printStackTrace();


### PR DESCRIPTION
Following commits have been split out from #68. They all should be simple and non-controversial. They make the code code more uniform and fix some low-priority FindBugs issues. I think we can get them to the next release without waiting for more invasive changes to be approved.