### PR TITLE
Make project and repository name available everywhere in project configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ The plugin provides following environment variables to the build:
 
 If the project has a parameter with the name of one of those environment variables, the value of the parameter is replaced with the value of that environment variable.
 
+Of those variables, `${destinationRepositoryOwner}` and `${destinationRepositoryName}` are available in all configuration fields. For instance, they can be used in the repository browser URL:
+`http://stash.example.com/projects/${destinationRepositoryOwner}/repos/${destinationRepositoryName}/`
+
+Other variables are only available in the fields evaluated in context of a specific build, e.g. in the git repository URL or in the shell commands to be run.
+
 ## Creating a Job
 
 **Source Code Management**

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildEnvironmentContributor.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildEnvironmentContributor.java
@@ -4,12 +4,14 @@ import hudson.EnvVars;
 import hudson.Extension;
 import hudson.model.AbstractBuild;
 import hudson.model.EnvironmentContributor;
+import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nonnull;
+import jenkins.model.ParameterizedJobMixIn;
 
 @Extension
 public class StashBuildEnvironmentContributor extends EnvironmentContributor {
@@ -31,6 +33,20 @@ public class StashBuildEnvironmentContributor extends EnvironmentContributor {
     }
 
     super.buildEnvironmentFor(r, envs, listener);
+  }
+
+  @Override
+  public void buildEnvironmentFor(
+      @Nonnull Job job, @Nonnull EnvVars envs, @Nonnull TaskListener listener)
+      throws IOException, InterruptedException {
+
+    StashBuildTrigger trigger = ParameterizedJobMixIn.getTrigger(job, StashBuildTrigger.class);
+    if (trigger != null) {
+      putEnvVar(envs, "destinationRepositoryOwner", trigger.getProjectCode());
+      putEnvVar(envs, "destinationRepositoryName", trigger.getRepositoryName());
+    }
+
+    super.buildEnvironmentFor(job, envs, listener);
   }
 
   private static void putEnvVar(EnvVars envs, String key, String value) {

--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildEnvironmentContributorTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildEnvironmentContributorTest.java
@@ -8,9 +8,14 @@ import static org.mockito.Mockito.when;
 
 import hudson.EnvVars;
 import hudson.model.Build;
+import hudson.model.FreeStyleProject;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.triggers.Trigger;
+import hudson.triggers.TriggerDescriptor;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -118,6 +123,40 @@ public class StashBuildEnvironmentContributorTest {
     Job<?, ?> job = mock(Job.class);
 
     contributor.buildEnvironmentFor(job, envVars, listener);
+    assertThat(envVars, is(anEmptyMap()));
+  }
+
+  @Test
+  public void populates_variables_for_FreeStyleProject() throws Exception {
+    FreeStyleProject job = mock(FreeStyleProject.class);
+    Map<TriggerDescriptor, Trigger<?>> triggerMap = new HashMap<TriggerDescriptor, Trigger<?>>();
+    StashBuildTrigger trigger = mock(StashBuildTrigger.class);
+    TriggerDescriptor triggerDescriptor = StashBuildTrigger.descriptor;
+    triggerMap.put(triggerDescriptor, trigger);
+
+    when(job.getTriggers()).thenReturn(triggerMap);
+    when(trigger.getProjectCode()).thenReturn("PROJ");
+    when(trigger.getRepositoryName()).thenReturn("Repo");
+
+    contributor.buildEnvironmentFor(job, envVars, listener);
+
+    assertThat(envVars.size(), is(2));
+    assertThat(envVars, hasEntry("destinationRepositoryName", "Repo"));
+    assertThat(envVars, hasEntry("destinationRepositoryOwner", "PROJ"));
+  }
+
+  @Test
+  public void no_variables_for_FreeStyleProject_without_StashBuildTrigger() throws Exception {
+    FreeStyleProject job = mock(FreeStyleProject.class);
+    Map<TriggerDescriptor, Trigger<?>> triggerMap = new HashMap<TriggerDescriptor, Trigger<?>>();
+    Trigger<?> trigger = mock(Trigger.class);
+    TriggerDescriptor triggerDescriptor = StashBuildTrigger.descriptor;
+    triggerMap.put(triggerDescriptor, trigger);
+
+    when(job.getTriggers()).thenReturn(triggerMap);
+
+    contributor.buildEnvironmentFor(job, envVars, listener);
+
     assertThat(envVars, is(anEmptyMap()));
   }
 }


### PR DESCRIPTION
```
*  Make project and repository name available everywhere in project configuration
   
   Make StashBuildEnvironmentContributor provide destinationRepositoryOwner
   and destinationRepositoryName variables through the buildEnvironmentFor()
   function with a Job argument.
   
   ${destinationRepositoryOwner} and ${destinationRepositoryName} can now be
   used in configuration fields that are not tied to a specific build.
   
   In particular, they can be used in the repository browser URL, e.g.
   http://stash/projects/${destinationRepositoryOwner}/repos/${destinationRepositoryName}/
   
   Builds triggered by Stash Pull Request Builder will have those variables
   replaced with the actual values from the pull request.
```