### PR TITLE
StashBuildListener: Get the trigger using ParameterizedJobMixIn.getTrigger()

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildListener.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildListener.java
@@ -7,6 +7,7 @@ import hudson.model.listeners.RunListener;
 import java.lang.invoke.MethodHandles;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
+import jenkins.model.ParameterizedJobMixIn;
 
 /** Created by Nathan McCarthy */
 @Extension
@@ -17,7 +18,8 @@ public class StashBuildListener extends RunListener<AbstractBuild<?, ?>> {
   @Override
   public void onStarted(AbstractBuild<?, ?> abstractBuild, TaskListener listener) {
     logger.info("BuildListener onStarted called.");
-    StashBuildTrigger trigger = StashBuildTrigger.getTrigger(abstractBuild.getProject());
+    StashBuildTrigger trigger =
+        ParameterizedJobMixIn.getTrigger(abstractBuild.getParent(), StashBuildTrigger.class);
     if (trigger == null) {
       return;
     }
@@ -26,7 +28,8 @@ public class StashBuildListener extends RunListener<AbstractBuild<?, ?>> {
 
   @Override
   public void onCompleted(AbstractBuild<?, ?> abstractBuild, @Nonnull TaskListener listener) {
-    StashBuildTrigger trigger = StashBuildTrigger.getTrigger(abstractBuild.getProject());
+    StashBuildTrigger trigger =
+        ParameterizedJobMixIn.getTrigger(abstractBuild.getParent(), StashBuildTrigger.class);
     if (trigger == null) {
       return;
     }

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -208,10 +208,6 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     }
   }
 
-  public static StashBuildTrigger getTrigger(AbstractProject<?, ?> project) {
-    return project.getTrigger(StashBuildTrigger.class);
-  }
-
   public StashPullRequestsBuilder getBuilder() {
     return this.stashPullRequestsBuilder;
   }


### PR DESCRIPTION
```
*  StashBuildListener: Get the trigger using ParameterizedJobMixIn.getTrigger()
   
   Remove StashBuildTrigger.getTrigger(), it's not used anymore.
```

This is a small change extracted from #69 that reduces dependencies between classes. It will be used in other PRs to allow easy merging.