### PR TITLE
StashRepository: Change constructor to get needed objects directly

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPullRequestsBuilder.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPullRequestsBuilder.java
@@ -22,7 +22,7 @@ public class StashPullRequestsBuilder {
       @Nonnull AbstractProject<?, ?> project, @Nonnull StashBuildTrigger trigger) {
     this.project = project;
     this.trigger = trigger;
-    this.repository = new StashRepository(this);
+    this.repository = new StashRepository(project, trigger);
     this.builds = new StashBuilds(trigger, repository);
   }
 


### PR DESCRIPTION
```
*  StashRepository: Change constructor to get needed objects directly
   
   The StashPullRequestsBuilder object is not needed, but the project and
   the trigger are used a lot, so pass them to the constructor. Annotate the
   constructor arguments with @Nonnull.
   
   No need to defer setting trigger until the init() call, it is not going
   to change.
   
   Passing the needed objects directly simplifies mock object injection in
   unit tests.
```
Both #81 and #86 need to make changes to this code. This is the common foundation for both.