### PR TITLE
Fix credential matching by Stash URL

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -353,7 +353,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     }
 
     public ListBoxModel doFillCredentialsIdItems(
-        @AncestorInPath Item context, @QueryParameter String source) {
+        @AncestorInPath Item context, @QueryParameter String stashHost) {
       if (context == null || !context.hasPermission(Item.CONFIGURE)) {
         return new ListBoxModel();
       }
@@ -365,7 +365,7 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
                   : ACL.SYSTEM,
               context,
               StandardUsernamePasswordCredentials.class,
-              URIRequirementBuilder.fromUri(source).build());
+              URIRequirementBuilder.fromUri(stashHost).build());
     }
   }
 }


### PR DESCRIPTION
The arguments to doFillCredentialsIdItems() should have specific names to
receive values from the correct fields.

The "source" parameter was null, so credentials from all domains were
selectable. "stashHost" gets the value from the "Stash URL" field and
uses it to limit credentials to those from matching domains.