### PR TITLE
[BUGFIX] Fix handling of failures to fetch the PR list and the PR comments

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -156,26 +156,25 @@ public class StashRepository {
     String id = pullRequest.getId();
     List<StashPullRequestComment> comments =
         client.getPullRequestComments(owner, repositoryName, id);
-    if (comments != null) {
-      // Process newest comments last so they can override older comments
-      Collections.sort(comments);
 
-      Map<String, String> result = new TreeMap<String, String>();
+    // Process newest comments last so they can override older comments
+    Collections.sort(comments);
 
-      for (StashPullRequestComment comment : comments) {
-        String content = comment.getText();
-        if (content == null || content.isEmpty()) {
-          continue;
-        }
+    Map<String, String> result = new TreeMap<String, String>();
 
-        Map<String, String> parameters = getParametersFromContent(content);
-        for (Map.Entry<String, String> parameter : parameters.entrySet()) {
-          result.put(parameter.getKey(), parameter.getValue());
-        }
+    for (StashPullRequestComment comment : comments) {
+      String content = comment.getText();
+      if (content == null || content.isEmpty()) {
+        continue;
       }
-      return result;
+
+      Map<String, String> parameters = getParametersFromContent(content);
+      for (Map.Entry<String, String> parameter : parameters.entrySet()) {
+        result.put(parameter.getKey(), parameter.getValue());
+      }
     }
-    return null;
+
+    return result;
   }
 
   private boolean hasCauseFromTheSamePullRequest(
@@ -407,20 +406,18 @@ public class StashRepository {
     List<StashPullRequestComment> comments =
         client.getPullRequestComments(owner, repositoryName, id);
 
-    if (comments != null) {
-      for (StashPullRequestComment comment : comments) {
-        String content = comment.getText();
-        if (content == null || content.isEmpty()) {
-          continue;
-        }
+    for (StashPullRequestComment comment : comments) {
+      String content = comment.getText();
+      if (content == null || content.isEmpty()) {
+        continue;
+      }
 
-        String project_build_finished = format(BUILD_FINISH_REGEX, job.getDisplayName());
-        Matcher finishMatcher =
-            Pattern.compile(project_build_finished, Pattern.CASE_INSENSITIVE).matcher(content);
+      String project_build_finished = format(BUILD_FINISH_REGEX, job.getDisplayName());
+      Matcher finishMatcher =
+          Pattern.compile(project_build_finished, Pattern.CASE_INSENSITIVE).matcher(content);
 
-        if (finishMatcher.find()) {
-          deletePullRequestComment(pullRequest.getId(), comment.getCommentId().toString());
-        }
+      if (finishMatcher.find()) {
+        deletePullRequestComment(pullRequest.getId(), comment.getCommentId().toString());
       }
     }
   }
@@ -474,66 +471,64 @@ public class StashRepository {
       return false;
     }
 
-    if (comments != null) {
-      // Start with most recent comments
-      Collections.sort(comments, Collections.reverseOrder());
+    // Start with most recent comments
+    Collections.sort(comments, Collections.reverseOrder());
 
-      for (StashPullRequestComment comment : comments) {
-        String content = comment.getText();
-        if (content == null || content.isEmpty()) {
-          continue;
+    for (StashPullRequestComment comment : comments) {
+      String content = comment.getText();
+      if (content == null || content.isEmpty()) {
+        continue;
+      }
+
+      // These will match any start or finish message -- need to check commits
+      String escapedBuildName = Pattern.quote(job.getDisplayName());
+      String project_build_start = String.format(BUILD_START_REGEX, escapedBuildName);
+      String project_build_finished = String.format(BUILD_FINISH_REGEX, escapedBuildName);
+      Matcher startMatcher =
+          Pattern.compile(project_build_start, Pattern.CASE_INSENSITIVE).matcher(content);
+      Matcher finishMatcher =
+          Pattern.compile(project_build_finished, Pattern.CASE_INSENSITIVE).matcher(content);
+
+      if (startMatcher.find() || finishMatcher.find()) {
+        // in build only on comment, we should stop parsing comments as soon as a PR builder
+        // comment is found.
+        if (isOnlyBuildOnComment) {
+          assert !shouldBuild;
+          break;
         }
 
-        // These will match any start or finish message -- need to check commits
-        String escapedBuildName = Pattern.quote(job.getDisplayName());
-        String project_build_start = String.format(BUILD_START_REGEX, escapedBuildName);
-        String project_build_finished = String.format(BUILD_FINISH_REGEX, escapedBuildName);
-        Matcher startMatcher =
-            Pattern.compile(project_build_start, Pattern.CASE_INSENSITIVE).matcher(content);
-        Matcher finishMatcher =
-            Pattern.compile(project_build_finished, Pattern.CASE_INSENSITIVE).matcher(content);
+        String sourceCommitMatch;
+        String destinationCommitMatch;
 
-        if (startMatcher.find() || finishMatcher.find()) {
-          // in build only on comment, we should stop parsing comments as soon as a PR builder
-          // comment is found.
-          if (isOnlyBuildOnComment) {
-            assert !shouldBuild;
-            break;
-          }
-
-          String sourceCommitMatch;
-          String destinationCommitMatch;
-
-          if (startMatcher.find(0)) {
-            sourceCommitMatch = startMatcher.group(1);
-            destinationCommitMatch = startMatcher.group(2);
-          } else {
-            sourceCommitMatch = finishMatcher.group(1);
-            destinationCommitMatch = finishMatcher.group(2);
-          }
-
-          // first check source commit -- if it doesn't match, just move on. If it does,
-          // investigate further.
-          if (sourceCommitMatch.equalsIgnoreCase(sourceCommit)) {
-            // if we're checking destination commits, and if this doesn't match, then move on.
-            if (this.trigger.getCheckDestinationCommit()
-                && (!destinationCommitMatch.equalsIgnoreCase(destinationCommit))) {
-              continue;
-            }
-
-            shouldBuild = false;
-            break;
-          }
+        if (startMatcher.find(0)) {
+          sourceCommitMatch = startMatcher.group(1);
+          destinationCommitMatch = startMatcher.group(2);
+        } else {
+          sourceCommitMatch = finishMatcher.group(1);
+          destinationCommitMatch = finishMatcher.group(2);
         }
 
-        if (isSkipBuild(content)) {
+        // first check source commit -- if it doesn't match, just move on. If it does,
+        // investigate further.
+        if (sourceCommitMatch.equalsIgnoreCase(sourceCommit)) {
+          // if we're checking destination commits, and if this doesn't match, then move on.
+          if (this.trigger.getCheckDestinationCommit()
+              && (!destinationCommitMatch.equalsIgnoreCase(destinationCommit))) {
+            continue;
+          }
+
           shouldBuild = false;
           break;
         }
-        if (isPhrasesContain(content, this.trigger.getCiBuildPhrases())) {
-          shouldBuild = true;
-          break;
-        }
+      }
+
+      if (isSkipBuild(content)) {
+        shouldBuild = false;
+        break;
+      }
+      if (isPhrasesContain(content, this.trigger.getCiBuildPhrases())) {
+        shouldBuild = true;
+        break;
       }
     }
     if (shouldBuild) {

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashApiClient;
+import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashApiClient.StashApiException;
 import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashPullRequestComment;
 import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashPullRequestMergeableResponse;
 import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashPullRequestResponseValue;
@@ -91,9 +92,17 @@ public class StashRepository {
 
   public Collection<StashPullRequestResponseValue> getTargetPullRequests() {
     logger.info(format("Fetch PullRequests (%s).", job.getName()));
-    List<StashPullRequestResponseValue> pullRequests = client.getPullRequests();
     List<StashPullRequestResponseValue> targetPullRequests =
         new ArrayList<StashPullRequestResponseValue>();
+
+    List<StashPullRequestResponseValue> pullRequests;
+    try {
+      pullRequests = client.getPullRequests();
+    } catch (StashApiException e) {
+      logger.info(format("%s: cannot fetch pull request list: %s", job.getName(), e));
+      return targetPullRequests;
+    }
+
     for (StashPullRequestResponseValue pullRequest : pullRequests) {
       if (isBuildTarget(pullRequest)) {
         targetPullRequests.add(pullRequest);
@@ -138,7 +147,8 @@ public class StashRepository {
     return result;
   }
 
-  public Map<String, String> getAdditionalParameters(StashPullRequestResponseValue pullRequest) {
+  public Map<String, String> getAdditionalParameters(StashPullRequestResponseValue pullRequest)
+      throws StashApiException {
     StashPullRequestResponseValueRepository destination = pullRequest.getToRef();
     String owner = destination.getRepository().getProjectName();
     String repositoryName = destination.getRepository().getRepositoryName();
@@ -252,10 +262,29 @@ public class StashRepository {
 
   public void addFutureBuildTasks(Collection<StashPullRequestResponseValue> pullRequests) {
     for (StashPullRequestResponseValue pullRequest : pullRequests) {
-      Map<String, String> additionalParameters = getAdditionalParameters(pullRequest);
-      if (trigger.getDeletePreviousBuildFinishComments()) {
-        deletePreviousBuildFinishedComments(pullRequest);
+      Map<String, String> additionalParameters;
+
+      try {
+        additionalParameters = getAdditionalParameters(pullRequest);
+      } catch (StashApiException e) {
+        logger.info(
+            format(
+                "%s: cannot read additional parameters for pull request %s, skipping: %s",
+                job.getName(), pullRequest.getId(), e));
+        continue;
       }
+
+      if (trigger.getDeletePreviousBuildFinishComments()) {
+        try {
+          deletePreviousBuildFinishedComments(pullRequest);
+        } catch (StashApiException e) {
+          logger.info(
+              format(
+                  "%s: cannot delete old \"BuildFinished\" comments for pull request %s: %s",
+                  job.getName(), pullRequest, e));
+        }
+      }
+
       String commentId = postBuildStartCommentTo(pullRequest);
       StashCause cause =
           new StashCause(
@@ -367,7 +396,8 @@ public class StashRepository {
     return true;
   }
 
-  private void deletePreviousBuildFinishedComments(StashPullRequestResponseValue pullRequest) {
+  private void deletePreviousBuildFinishedComments(StashPullRequestResponseValue pullRequest)
+      throws StashApiException {
 
     StashPullRequestResponseValueRepository destination = pullRequest.getToRef();
     String owner = destination.getRepository().getProjectName();
@@ -436,8 +466,13 @@ public class StashRepository {
     String destinationCommit = destination.getLatestCommit();
 
     String id = pullRequest.getId();
-    List<StashPullRequestComment> comments =
-        client.getPullRequestComments(owner, repositoryName, id);
+    List<StashPullRequestComment> comments;
+    try {
+      comments = client.getPullRequestComments(owner, repositoryName, id);
+    } catch (StashApiException e) {
+      logger.info(format("%s: cannot read pull request comments: %s", job.getName(), e));
+      return false;
+    }
 
     if (comments != null) {
       // Start with most recent comments

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
@@ -90,6 +91,7 @@ public class StashApiClient {
     }
   }
 
+  @Nonnull
   public List<StashPullRequestResponseValue> getPullRequests() throws StashApiException {
     List<StashPullRequestResponseValue> pullRequestResponseValues =
         new ArrayList<StashPullRequestResponseValue>();
@@ -111,6 +113,7 @@ public class StashApiClient {
     }
   }
 
+  @Nonnull
   public List<StashPullRequestComment> getPullRequestComments(
       String projectCode, String commentRepositoryName, String pullRequestId)
       throws StashApiException {
@@ -453,6 +456,7 @@ public class StashApiClient {
     return parsedResponse;
   }
 
+  @Nonnull
   private List<StashPullRequestComment> extractComments(
       List<StashPullRequestActivityResponse> responses) {
     List<StashPullRequestComment> comments = new ArrayList<StashPullRequestComment>();

--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepositoryTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
@@ -29,6 +30,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import jenkins.model.Jenkins;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,6 +43,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.junit.MockitoRule;
 import org.mockito.quality.Strictness;
 import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashApiClient;
+import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashApiClient.StashApiException;
 import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashPullRequestComment;
 import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashPullRequestResponseValue;
 import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashPullRequestResponseValueRepository;
@@ -123,14 +126,14 @@ public class StashRepositoryTest {
   }
 
   @Test
-  public void getTargetPullRequestsReturnsEmptyListForNoPullRequests() {
+  public void getTargetPullRequestsReturnsEmptyListForNoPullRequests() throws Exception {
     when(stashApiClient.getPullRequests()).thenReturn(Collections.emptyList());
 
     assertThat(stashRepository.getTargetPullRequests(), empty());
   }
 
   @Test
-  public void getTargetPullRequestsAcceptsOpenPullRequests() {
+  public void getTargetPullRequestsAcceptsOpenPullRequests() throws Exception {
     when(stashApiClient.getPullRequests()).thenReturn(pullRequestList);
     when(trigger.getCiSkipPhrases()).thenReturn("NO TEST");
 
@@ -138,7 +141,7 @@ public class StashRepositoryTest {
   }
 
   @Test
-  public void getTargetPullRequestsSkipsMergedPullRequests() {
+  public void getTargetPullRequestsSkipsMergedPullRequests() throws Exception {
     when(stashApiClient.getPullRequests()).thenReturn(pullRequestList);
     pullRequest.setState("MERGED");
 
@@ -146,7 +149,7 @@ public class StashRepositoryTest {
   }
 
   @Test
-  public void getTargetPullRequestsSkipsNullStatePullRequests() {
+  public void getTargetPullRequestsSkipsNullStatePullRequests() throws Exception {
     when(stashApiClient.getPullRequests()).thenReturn(pullRequestList);
     pullRequest.setState(null);
 
@@ -154,7 +157,7 @@ public class StashRepositoryTest {
   }
 
   @Test
-  public void getTargetPullRequestsAcceptsMatchingBranches() {
+  public void getTargetPullRequestsAcceptsMatchingBranches() throws Exception {
     when(stashApiClient.getPullRequests()).thenReturn(pullRequestList);
     when(trigger.getCiSkipPhrases()).thenReturn("NO TEST");
     when(trigger.getTargetBranchesToBuild()).thenReturn("release/.*,feature/.*,testing/.*");
@@ -163,7 +166,7 @@ public class StashRepositoryTest {
   }
 
   @Test
-  public void getTargetPullRequestsAcceptsMatchingBranchesWithPadding() {
+  public void getTargetPullRequestsAcceptsMatchingBranchesWithPadding() throws Exception {
     when(stashApiClient.getPullRequests()).thenReturn(pullRequestList);
     when(trigger.getCiSkipPhrases()).thenReturn("NO TEST");
     when(trigger.getTargetBranchesToBuild())
@@ -173,7 +176,7 @@ public class StashRepositoryTest {
   }
 
   @Test
-  public void getTargetPullRequestsSkipsMismatchingBranches() {
+  public void getTargetPullRequestsSkipsMismatchingBranches() throws Exception {
     when(stashApiClient.getPullRequests()).thenReturn(pullRequestList);
     when(trigger.getCiSkipPhrases()).thenReturn("NO TEST");
     when(trigger.getTargetBranchesToBuild()).thenReturn("release/.*,testing/.*");
@@ -182,7 +185,7 @@ public class StashRepositoryTest {
   }
 
   @Test
-  public void getTargetPullRequestsAcceptsAnyBranchIfBranchesToBuildIsEmpty() {
+  public void getTargetPullRequestsAcceptsAnyBranchIfBranchesToBuildIsEmpty() throws Exception {
     when(stashApiClient.getPullRequests()).thenReturn(pullRequestList);
     when(trigger.getCiSkipPhrases()).thenReturn("NO TEST");
     when(trigger.getTargetBranchesToBuild()).thenReturn("");
@@ -191,7 +194,7 @@ public class StashRepositoryTest {
   }
 
   @Test
-  public void getTargetPullRequestsAcceptsAnyBranchIfBranchesToBuildIsNull() {
+  public void getTargetPullRequestsAcceptsAnyBranchIfBranchesToBuildIsNull() throws Exception {
     when(stashApiClient.getPullRequests()).thenReturn(pullRequestList);
     when(trigger.getCiSkipPhrases()).thenReturn("NO TEST");
     when(trigger.getTargetBranchesToBuild()).thenReturn(null);
@@ -200,7 +203,7 @@ public class StashRepositoryTest {
   }
 
   @Test
-  public void getTargetPullRequestsSkipsOnSkipPhraseInTitle() {
+  public void getTargetPullRequestsSkipsOnSkipPhraseInTitle() throws Exception {
     pullRequest.setTitle("NO TEST");
 
     when(stashApiClient.getPullRequests()).thenReturn(pullRequestList);
@@ -210,7 +213,7 @@ public class StashRepositoryTest {
   }
 
   @Test
-  public void getTargetPullRequestsSkipsOnSkipPhraseInComments() {
+  public void getTargetPullRequestsSkipsOnSkipPhraseInComments() throws Exception {
     StashPullRequestComment comment = new StashPullRequestComment();
     comment.setText("NO TEST");
     List<StashPullRequestComment> comments = Collections.singletonList(comment);
@@ -224,7 +227,7 @@ public class StashRepositoryTest {
   }
 
   @Test
-  public void getTargetPullRequestsPrioritizesLatestComments() {
+  public void getTargetPullRequestsPrioritizesLatestComments() throws Exception {
     StashPullRequestComment comment1 = new StashPullRequestComment();
     comment1.setCommentId(1);
     comment1.setText("NO TEST");
@@ -245,7 +248,7 @@ public class StashRepositoryTest {
   }
 
   @Test
-  public void getTargetPullRequestsSkipPhraseIsCaseInsensitive() {
+  public void getTargetPullRequestsSkipPhraseIsCaseInsensitive() throws Exception {
     pullRequest.setTitle("Disable any testing");
 
     when(stashApiClient.getPullRequests()).thenReturn(pullRequestList);
@@ -255,7 +258,7 @@ public class StashRepositoryTest {
   }
 
   @Test
-  public void getTargetPullRequestsSkipPhraseMatchedAsSubstring() {
+  public void getTargetPullRequestsSkipPhraseMatchedAsSubstring() throws Exception {
     pullRequest.setTitle("This will get no testing whatsoever");
 
     when(stashApiClient.getPullRequests()).thenReturn(pullRequestList);
@@ -265,7 +268,7 @@ public class StashRepositoryTest {
   }
 
   @Test
-  public void getTargetPullRequestsSupportsMultipleSkipPhrasesAndPadding() {
+  public void getTargetPullRequestsSupportsMultipleSkipPhrasesAndPadding() throws Exception {
     pullRequest.setTitle("This will get no testing whatsoever");
 
     when(stashApiClient.getPullRequests()).thenReturn(pullRequestList);
@@ -275,7 +278,7 @@ public class StashRepositoryTest {
   }
 
   @Test
-  public void getTargetPullRequestsBuildsIfSkipPhraseIsEmpty() {
+  public void getTargetPullRequestsBuildsIfSkipPhraseIsEmpty() throws Exception {
     pullRequest.setTitle("NO TEST");
 
     when(stashApiClient.getPullRequests()).thenReturn(pullRequestList);
@@ -285,7 +288,7 @@ public class StashRepositoryTest {
   }
 
   @Test
-  public void getTargetPullRequestsBuildsIfSkipPhraseIsNull() {
+  public void getTargetPullRequestsBuildsIfSkipPhraseIsNull() throws Exception {
     pullRequest.setTitle("NO TEST");
 
     when(stashApiClient.getPullRequests()).thenReturn(pullRequestList);
@@ -295,7 +298,7 @@ public class StashRepositoryTest {
   }
 
   @Test
-  public void getAdditionalParametersUsesNewestParameterDefinition() {
+  public void getAdditionalParametersUsesNewestParameterDefinition() throws Exception {
     StashPullRequestComment comment1 = new StashPullRequestComment();
     comment1.setCommentId(1);
     comment1.setText("p:key=value1");
@@ -314,7 +317,8 @@ public class StashRepositoryTest {
   }
 
   @Test
-  public void getAdditionalParametersUsesNewestParameterDefinitionRegardlessOfListOrder() {
+  public void getAdditionalParametersUsesNewestParameterDefinitionRegardlessOfListOrder()
+      throws Exception {
     StashPullRequestComment comment1 = new StashPullRequestComment();
     comment1.setCommentId(1);
     comment1.setText("p:key=value1");
@@ -333,7 +337,7 @@ public class StashRepositoryTest {
   }
 
   @Test
-  public void addFutureBuildTasksRemovesOldBuildFinishedCommentsIfEnabled() {
+  public void addFutureBuildTasksRemovesOldBuildFinishedCommentsIfEnabled() throws Exception {
     StashPullRequestComment comment1 = new StashPullRequestComment();
     comment1.setCommentId(1);
     comment1.setText("[*BuildFinished* **MyProject**] DEADBEEF into 1BADFACE");
@@ -436,5 +440,34 @@ public class StashRepositoryTest {
     List<ParameterValue> parameters = captureBuildParameters();
 
     assertThat(parameters, is(empty()));
+  }
+
+  @Test
+  public void getTargetPullRequests_returns_empty_if_getPullRequests_throws() throws Exception {
+    when(stashApiClient.getPullRequests()).thenThrow(new StashApiException("cannot read PR list"));
+
+    assertThat(stashRepository.getTargetPullRequests(), is(empty()));
+  }
+
+  @Test
+  public void getTargetPullRequests_skips_pull_request_if_getPullRequestComments_throws()
+      throws Exception {
+    when(stashApiClient.getPullRequests()).thenReturn(pullRequestList);
+    when(trigger.getCiSkipPhrases()).thenReturn("NO TEST");
+    when(stashApiClient.getPullRequestComments(any(), any(), any()))
+        .thenThrow(new StashApiException("cannot read PR comments"));
+
+    assertThat(stashRepository.getTargetPullRequests(), is(empty()));
+  }
+
+  @Test
+  public void addFutureBuildTasks_skips_scheduling_build_if_getPullRequestComments_throws()
+      throws Exception {
+    when(stashApiClient.getPullRequestComments(any(), any(), any()))
+        .thenThrow(new StashApiException("cannot read PR comments"));
+
+    stashRepository.addFutureBuildTasks(pullRequestList);
+
+    assertThat(Jenkins.getInstance().getQueue().getItems(), is(emptyArray()));
   }
 }


### PR DESCRIPTION
```
*  Fix handling of failures to fetch the PR list and the PR comments
   
   Add a new exception StashApiException, throw it in both cases.
   
   Don't trigger a build on a failure to fetch PR comments. That issue has
   been observed creating a large number of builds if the connection between
   Jenkins and Stash is unstable.
```