### PR TITLE
StashBuildEnvironmentContributor: Pass environment variables to pipelines

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildEnvironmentContributor.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildEnvironmentContributor.java
@@ -16,23 +16,24 @@ public class StashBuildEnvironmentContributor extends EnvironmentContributor {
   public void buildEnvironmentFor(
       @Nonnull Run r, @Nonnull EnvVars envs, @Nonnull TaskListener listener)
       throws IOException, InterruptedException {
+    Run<?, ?> run = r;
     if (r instanceof AbstractBuild) {
       AbstractBuild<?, ?> build = (AbstractBuild<?, ?>) r;
-      AbstractBuild<?, ?> rootBuild = build.getRootBuild();
+      run = build.getRootBuild();
+    }
 
-      StashCause cause = rootBuild.getCause(StashCause.class);
-      if (cause != null) {
-        putEnvVar(envs, "sourceBranch", cause.getSourceBranch());
-        putEnvVar(envs, "targetBranch", cause.getTargetBranch());
-        putEnvVar(envs, "sourceRepositoryOwner", cause.getSourceRepositoryOwner());
-        putEnvVar(envs, "sourceRepositoryName", cause.getSourceRepositoryName());
-        putEnvVar(envs, "pullRequestId", cause.getPullRequestId());
-        putEnvVar(envs, "destinationRepositoryOwner", cause.getDestinationRepositoryOwner());
-        putEnvVar(envs, "destinationRepositoryName", cause.getDestinationRepositoryName());
-        putEnvVar(envs, "pullRequestTitle", cause.getPullRequestTitle());
-        putEnvVar(envs, "sourceCommitHash", cause.getSourceCommitHash());
-        putEnvVar(envs, "destinationCommitHash", cause.getDestinationCommitHash());
-      }
+    StashCause cause = run.getCause(StashCause.class);
+    if (cause != null) {
+      putEnvVar(envs, "sourceBranch", cause.getSourceBranch());
+      putEnvVar(envs, "targetBranch", cause.getTargetBranch());
+      putEnvVar(envs, "sourceRepositoryOwner", cause.getSourceRepositoryOwner());
+      putEnvVar(envs, "sourceRepositoryName", cause.getSourceRepositoryName());
+      putEnvVar(envs, "pullRequestId", cause.getPullRequestId());
+      putEnvVar(envs, "destinationRepositoryOwner", cause.getDestinationRepositoryOwner());
+      putEnvVar(envs, "destinationRepositoryName", cause.getDestinationRepositoryName());
+      putEnvVar(envs, "pullRequestTitle", cause.getPullRequestTitle());
+      putEnvVar(envs, "sourceCommitHash", cause.getSourceCommitHash());
+      putEnvVar(envs, "destinationCommitHash", cause.getDestinationCommitHash());
     }
 
     super.buildEnvironmentFor(r, envs, listener);

--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildEnvironmentContributorTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildEnvironmentContributorTest.java
@@ -73,8 +73,18 @@ public class StashBuildEnvironmentContributorTest {
   }
 
   @Test
-  public void noVariablesForRun() throws Exception {
+  public void populatesVariablesForRun() throws Exception {
     Run<?, ?> run = mock(Run.class);
+    when(run.getCause(StashCause.class)).thenReturn(cause);
+
+    contributor.buildEnvironmentFor(run, envVars, listener);
+    checkEnvVars();
+  }
+
+  @Test
+  public void noVariablesForRunWithoutCause() throws Exception {
+    Run<?, ?> run = mock(Run.class);
+    when(run.getCause(StashCause.class)).thenReturn(null);
 
     contributor.buildEnvironmentFor(run, envVars, listener);
     assertThat(envVars, is(anEmptyMap()));

--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildEnvironmentContributorTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildEnvironmentContributorTest.java
@@ -1,0 +1,113 @@
+package stashpullrequestbuilder.stashpullrequestbuilder;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import hudson.EnvVars;
+import hudson.model.Build;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StashBuildEnvironmentContributorTest {
+
+  @Rule public JenkinsRule jenkinsRule = new JenkinsRule();
+  @Rule public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+
+  private StashBuildEnvironmentContributor contributor;
+
+  private EnvVars envVars;
+  private StashCause cause;
+
+  @Mock private TaskListener listener;
+
+  @Before
+  public void before() {
+    contributor = new StashBuildEnvironmentContributor();
+    envVars = new EnvVars();
+    cause =
+        new StashCause(
+            "StashHost",
+            "SourceBranch",
+            "TargetBranch",
+            "SourceRepositoryOwner",
+            "SourceRepositoryName",
+            "PullRequestId",
+            "DestinationRepositoryOwner",
+            "DestinationRepositoryName",
+            "PullRequestTitle",
+            "SourceCommitHash",
+            "DestinationCommitHash",
+            "BuildStartCommentId",
+            "PullRequestVersion",
+            null);
+  }
+
+  private void checkEnvVars() {
+    assertThat(envVars.size(), is(10));
+
+    assertThat(envVars, hasEntry("destinationCommitHash", "DestinationCommitHash"));
+    assertThat(envVars, hasEntry("destinationRepositoryName", "DestinationRepositoryName"));
+    assertThat(envVars, hasEntry("destinationRepositoryOwner", "DestinationRepositoryOwner"));
+    assertThat(envVars, hasEntry("pullRequestId", "PullRequestId"));
+    assertThat(envVars, hasEntry("pullRequestTitle", "PullRequestTitle"));
+    assertThat(envVars, hasEntry("sourceBranch", "SourceBranch"));
+    assertThat(envVars, hasEntry("sourceCommitHash", "SourceCommitHash"));
+    assertThat(envVars, hasEntry("sourceRepositoryName", "SourceRepositoryName"));
+    assertThat(envVars, hasEntry("sourceRepositoryOwner", "SourceRepositoryOwner"));
+    assertThat(envVars, hasEntry("targetBranch", "TargetBranch"));
+  }
+
+  @Test
+  public void noVariablesForRun() throws Exception {
+    Run<?, ?> run = mock(Run.class);
+
+    contributor.buildEnvironmentFor(run, envVars, listener);
+    assertThat(envVars, is(anEmptyMap()));
+  }
+
+  @Test
+  public void populatesVariablesForRootBuild() throws Exception {
+    Build<?, ?> rootBuild = mock(Build.class);
+
+    doReturn(rootBuild).when(rootBuild).getRootBuild();
+    when(rootBuild.getCause(StashCause.class)).thenReturn(cause);
+
+    contributor.buildEnvironmentFor(rootBuild, envVars, listener);
+    checkEnvVars();
+  }
+
+  @Test
+  public void populatesVariablesForChildBuild() throws Exception {
+    Build<?, ?> childBuild = mock(Build.class);
+    Build<?, ?> rootBuild = mock(Build.class);
+
+    doReturn(rootBuild).when(childBuild).getRootBuild();
+    when(rootBuild.getCause(StashCause.class)).thenReturn(cause);
+
+    contributor.buildEnvironmentFor(childBuild, envVars, listener);
+    checkEnvVars();
+  }
+
+  @Test
+  public void noVariablesForJob() throws Exception {
+    Job<?, ?> job = mock(Job.class);
+
+    contributor.buildEnvironmentFor(job, envVars, listener);
+    assertThat(envVars, is(anEmptyMap()));
+  }
+}


### PR DESCRIPTION
```
*  StashBuildEnvironmentContributor: Pass environment variables to pipelines
   
   Add environment variables to every Run caused by StashCause even if it's
   not an instance of AbstractBuild.
```

Split from #69, as it's possible to set up a pipeline without relying on the environment variables provided by the plugin (although I would definitely recommend using `sourceCommitHash` to make sure the plugin tests what Bitbucket Server expects to be tested).