### PR TITLE
StashRepository: Clean up comment sorting, add comments

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -135,8 +135,8 @@ public class StashRepository {
     List<StashPullRequestComment> comments =
         client.getPullRequestComments(owner, repositoryName, id);
     if (comments != null) {
+      // Process newest comments last so they can override older comments
       Collections.sort(comments);
-      //          Collections.reverse(comments);
 
       Map<String, String> result = new TreeMap<String, String>();
 
@@ -284,8 +284,6 @@ public class StashRepository {
         client.getPullRequestComments(owner, repositoryName, id);
 
     if (comments != null) {
-      Collections.sort(comments);
-      Collections.reverse(comments);
       for (StashPullRequestComment comment : comments) {
         String content = comment.getText();
         if (content == null || content.isEmpty()) {
@@ -348,8 +346,9 @@ public class StashRepository {
         client.getPullRequestComments(owner, repositoryName, id);
 
     if (comments != null) {
-      Collections.sort(comments);
-      Collections.reverse(comments);
+      // Start with most recent comments
+      Collections.sort(comments, Collections.reverseOrder());
+
       for (StashPullRequestComment comment : comments) {
         String content = comment.getText();
         if (content == null || content.isEmpty()) {


### PR DESCRIPTION
When extracting parameters from comments, start with the oldest comments,
as the code iterates over all comments. Parameters from the new comments
are processed last, overwriting older values.

When deleting old "BUILD FINISHED" comments, don't sort the comments, it
doesn't matter in which order they are deleted.

When looking for comments to decide whether to run a build, start with
the most recent comments. The loop terminates early as soon as it's clear
whether to start the build or not. Don't sort and reverse the sort order
as two operations, use reverse sorting.