### PR TITLE
[TRIVIAL] StashRepository: Use Java style array declaration

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -115,7 +115,7 @@ public class StashRepository {
 
   public static Map<String, String> getParametersFromContent(String content) {
     Map<String, String> result = new TreeMap<String, String>();
-    String lines[] = content.split("\\r?\\n|\\r");
+    String[] lines = content.split("\\r?\\n|\\r");
     for (String line : lines) {
       AbstractMap.SimpleEntry<String, String> parameter = getParameter(line);
       if (parameter != null) {


### PR DESCRIPTION
```
*  StashRepository: Use Java style array declaration
   
   Using [] after the variable name is deprecated.
```

This should not conflict with anything 😉