### PR TITLE
[TRIVIAL] StashPostBuildComment: Protect against req=null in newInstance()

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPostBuildComment.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPostBuildComment.java
@@ -9,6 +9,7 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
 import hudson.tasks.Publisher;
+import javax.annotation.Nullable;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
@@ -63,8 +64,13 @@ public class StashPostBuildComment extends Notifier {
     }
 
     @Override
-    public StashPostBuildComment newInstance(StaplerRequest req, JSONObject formData)
+    public StashPostBuildComment newInstance(@Nullable StaplerRequest req, JSONObject formData)
         throws FormException {
+      if (req == null) {
+        // Should not happen according to the superclass documentation
+        throw new FormException("newInstance() called for null Stapler request", null);
+      }
+
       return req.bindJSON(StashPostBuildComment.class, formData);
     }
 


### PR DESCRIPTION
The "req" argument is marked as Nullable for historic reasons:
https://javadoc.jenkins.io/hudson/model/Descriptor.html#newInstance-org.kohsuke.stapler.StaplerRequest-

Still, the missing check for null appears in various code checkers, so
it's better to check for null to silence them.