### PR TITLE
Fill parameter values from environment variables added by the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ This plugin was inspired by the GitHub & BitBucket pull request builder plugins.
 - Jenkins 2.60.1 or higher.
 - [Git Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin)
 
-## Parameter variables
+## Environment variables
 
-The plugin makes available to the job the following parameter variables:
+The plugin provides following environment variables to the build:
+
 - `${pullRequestId}`
 - `${pullRequestTitle}`
 - `${sourceBranch}`
@@ -27,6 +28,8 @@ The plugin makes available to the job the following parameter variables:
 - `${destinationRepositoryName}`
 - `${sourceCommitHash}`
 - `${destinationCommitHash}`
+
+If the project has a parameter with the name of one of those environment variables, the value of the parameter is replaced with the value of that environment variable.
 
 ## Creating a Job
 
@@ -109,9 +112,11 @@ If you want to rerun pull request test, write *"test this please"* comment to yo
 
 ## Adding additional parameters to a build
 
-If you want to add additional parameters to the triggered build, add comments using the pattern `p:<parameter_name>=<value>`, one at each line, prefixed with `p:`. If the same parameter name appears multiple times the latest comment with that parameter will decide the value.
+If you want to add additional parameters to the triggered build, add comments using the pattern `p:<parameter_name>=<value>`, one at each line, prefixed with `p:`. If the same parameter name appears multiple times, the latest comment with that parameter will set the value.
 
 For security reasons, all the parameters should also be defined in the project. Select **This project is parameterized** in the configuration and add string parameters with the names you want to be read from the comments. Parameters with names not defined in the project will be ignored.
+
+Parameters from the pull request comments are not allowed to override the environment variables provided by the plugin.
 
 **Example:**
 

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildEnvironmentContributor.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildEnvironmentContributor.java
@@ -7,6 +7,7 @@ import hudson.model.EnvironmentContributor;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import java.io.IOException;
+import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 
@@ -24,16 +25,9 @@ public class StashBuildEnvironmentContributor extends EnvironmentContributor {
 
     StashCause cause = run.getCause(StashCause.class);
     if (cause != null) {
-      putEnvVar(envs, "sourceBranch", cause.getSourceBranch());
-      putEnvVar(envs, "targetBranch", cause.getTargetBranch());
-      putEnvVar(envs, "sourceRepositoryOwner", cause.getSourceRepositoryOwner());
-      putEnvVar(envs, "sourceRepositoryName", cause.getSourceRepositoryName());
-      putEnvVar(envs, "pullRequestId", cause.getPullRequestId());
-      putEnvVar(envs, "destinationRepositoryOwner", cause.getDestinationRepositoryOwner());
-      putEnvVar(envs, "destinationRepositoryName", cause.getDestinationRepositoryName());
-      putEnvVar(envs, "pullRequestTitle", cause.getPullRequestTitle());
-      putEnvVar(envs, "sourceCommitHash", cause.getSourceCommitHash());
-      putEnvVar(envs, "destinationCommitHash", cause.getDestinationCommitHash());
+      for (Map.Entry<String, String> variable : cause.getEnvironmentVariables().entrySet()) {
+        putEnvVar(envs, variable.getKey(), variable.getValue());
+      }
     }
 
     super.buildEnvironmentFor(r, envs, listener);

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashCause.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashCause.java
@@ -2,6 +2,7 @@ package stashpullrequestbuilder.stashpullrequestbuilder;
 
 import hudson.model.Cause;
 import java.util.Map;
+import java.util.TreeMap;
 
 /** Created by Nathan McCarthy */
 public class StashCause extends Cause {
@@ -19,6 +20,7 @@ public class StashCause extends Cause {
   private final String pullRequestVersion;
   private final String stashHost;
   private final Map<String, String> additionalParameters;
+  private final transient Map<String, String> environmentVariables;
 
   public StashCause(
       String stashHost,
@@ -49,6 +51,18 @@ public class StashCause extends Cause {
     this.pullRequestVersion = pullRequestVersion;
     this.stashHost = stashHost.replaceAll("/$", "");
     this.additionalParameters = additionalParameters;
+
+    environmentVariables = new TreeMap<>();
+    environmentVariables.put("sourceBranch", sourceBranch);
+    environmentVariables.put("targetBranch", targetBranch);
+    environmentVariables.put("sourceRepositoryOwner", sourceRepositoryOwner);
+    environmentVariables.put("sourceRepositoryName", sourceRepositoryName);
+    environmentVariables.put("pullRequestId", pullRequestId);
+    environmentVariables.put("destinationRepositoryOwner", destinationRepositoryOwner);
+    environmentVariables.put("destinationRepositoryName", destinationRepositoryName);
+    environmentVariables.put("pullRequestTitle", pullRequestTitle);
+    environmentVariables.put("sourceCommitHash", sourceCommitHash);
+    environmentVariables.put("destinationCommitHash", destinationCommitHash);
   }
 
   public String getSourceBranch() {
@@ -101,6 +115,10 @@ public class StashCause extends Cause {
 
   public Map<String, String> getAdditionalParameters() {
     return additionalParameters;
+  }
+
+  public Map<String, String> getEnvironmentVariables() {
+    return environmentVariables;
   }
 
   @Override

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -220,14 +220,15 @@ public class StashRepository {
   private List<ParameterValue> getParameters(StashCause cause) {
     List<ParameterValue> values = new ArrayList<ParameterValue>();
 
-    Map<String, String> additionalParameters = cause.getAdditionalParameters();
-
     ParametersDefinitionProperty definitionProperty =
         this.job.getProperty(ParametersDefinitionProperty.class);
 
     if (definitionProperty == null) {
       return values;
     }
+
+    Map<String, String> additionalParameters = cause.getAdditionalParameters();
+    Map<String, String> environmentVariables = cause.getEnvironmentVariables();
 
     for (ParameterDefinition definition : definitionProperty.getParameterDefinitions()) {
       String parameterName = definition.getName();
@@ -238,6 +239,11 @@ public class StashRepository {
         if (additionalParameter != null) {
           parameterValue = new StringParameterValue(parameterName, additionalParameter);
         }
+      }
+
+      String environmentValue = environmentVariables.get(parameterName);
+      if (environmentValue != null) {
+        parameterValue = new StringParameterValue(parameterName, environmentValue);
       }
 
       if (parameterValue != null) {

--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepositoryTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepositoryTest.java
@@ -447,6 +447,36 @@ public class StashRepositoryTest {
   }
 
   @Test
+  public void parameters_populated_from_StashCause() {
+    cause = makeCause(null);
+
+    ParameterDefinition parameterDefinition =
+        new StringParameterDefinition("sourceBranch", "DefaultBranch");
+    jobSetup(parameterDefinition);
+
+    List<ParameterValue> parameters = captureBuildParameters();
+
+    assertThat(
+        parameters, contains(new StringParameterValue("sourceBranch", cause.getSourceBranch())));
+  }
+
+  @Test
+  public void parameters_from_pull_request_comments_overridden_by_StashCause() {
+    Map<String, String> prParameters = new TreeMap<>();
+    prParameters.put("sourceBranch", "BranchFromPrComment");
+    cause = makeCause(prParameters);
+
+    ParameterDefinition parameterDefinition =
+        new StringParameterDefinition("sourceBranch", "DefaultBranch");
+    jobSetup(parameterDefinition);
+
+    List<ParameterValue> parameters = captureBuildParameters();
+
+    assertThat(
+        parameters, contains(new StringParameterValue("sourceBranch", cause.getSourceBranch())));
+  }
+
+  @Test
   public void getTargetPullRequests_returns_empty_if_getPullRequests_throws() throws Exception {
     when(stashApiClient.getPullRequests()).thenThrow(new StashApiException("cannot read PR list"));
 


### PR DESCRIPTION
```
*  Fill parameter values from environment variables added by the plugin
   
   Parameters generate environment variables that take precedence over the
   environment variables supplied by the EnvironmentContributor extension.
   
   Some users relied on the plugin filling values for the parameters defined
   for the project. That functionality was broken in version 1.9.
   
   Make StashRepository#getParameters() fill parameters with the values that
   the plugin supplies to the environment.
   
   To avoid code duplication, move the environment variables to StashCause
   as a transient map (the data is already saved to XML files from the
   fields). Use that map both from StashBuildEnvironmentContributor and
   StashRepository.
   
   Make the environment variables override the parameters from the pull
   request comments. Users with comment posting permissions should not be
   able to override parameters that the administrator intended to be filled
   from the environment.
```

Reported by @Noltari. Someone else mentioned that earlier in a PR comment, but I cannot find that comment.