### PR TITLE
StashRepository: Merge init() into the constructor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,12 @@
       <version>4.5.2</version>
     </dependency>
     <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock-jre8-standalone</artifactId>
+      <version>2.23.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
       <version>2.1</version>

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPullRequestsBuilder.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPullRequestsBuilder.java
@@ -26,7 +26,6 @@ public class StashPullRequestsBuilder {
 
   public void run() {
     logger.info(format("Build Start (%s).", project.getName()));
-    this.repository.init();
     Collection<StashPullRequestResponseValue> targetPullRequests =
         this.repository.getTargetPullRequests();
     this.repository.addFutureBuildTasks(targetPullRequests);

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -67,10 +67,10 @@ public class StashRepository {
   private StashApiClient client;
 
   public StashRepository(@Nonnull Job<?, ?> job, @Nonnull StashBuildTrigger trigger) {
-    this(job, trigger, null);
+    this(job, trigger, makeStashApiClient(trigger));
   }
 
-  // For unit tests only
+  // Visible for unit tests
   StashRepository(
       @Nonnull Job<?, ?> job, @Nonnull StashBuildTrigger trigger, StashApiClient client) {
     this.job = job;
@@ -78,15 +78,14 @@ public class StashRepository {
     this.client = client;
   }
 
-  public void init() {
-    client =
-        new StashApiClient(
-            trigger.getStashHost(),
-            trigger.getUsername(),
-            trigger.getPassword(),
-            trigger.getProjectCode(),
-            trigger.getRepositoryName(),
-            trigger.isIgnoreSsl());
+  private static StashApiClient makeStashApiClient(StashBuildTrigger trigger) {
+    return new StashApiClient(
+        trigger.getStashHost(),
+        trigger.getUsername(),
+        trigger.getPassword(),
+        trigger.getProjectCode(),
+        trigger.getRepositoryName(),
+        trigger.isIgnoreSsl());
   }
 
   public Collection<StashPullRequestResponseValue> getTargetPullRequests() {

--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepositoryTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepositoryTest.java
@@ -1,5 +1,13 @@
 package stashpullrequestbuilder.stashpullrequestbuilder;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.contains;
@@ -15,6 +23,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import hudson.model.BooleanParameterDefinition;
 import hudson.model.FileParameterDefinition;
 import hudson.model.FreeStyleProject;
@@ -54,6 +63,7 @@ public class StashRepositoryTest {
 
   @Rule public JenkinsRule jenkinsRule = new JenkinsRule();
   @Rule public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+  @Rule public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
 
   private StashRepository stashRepository;
 
@@ -494,5 +504,28 @@ public class StashRepositoryTest {
     stashRepository.addFutureBuildTasks(pullRequestList);
 
     assertThat(Jenkins.getInstance().getQueue().getItems(), is(emptyArray()));
+  }
+
+  @Test
+  public void constructor_initializes_StashApiClient() throws Exception {
+    String projectName = "PROJ";
+    String repositoryName = "Repo";
+
+    when(trigger.getStashHost()).thenReturn(wireMockRule.baseUrl());
+    when(trigger.getUsername()).thenReturn("User");
+    when(trigger.getPassword()).thenReturn("Password");
+    when(trigger.getProjectCode()).thenReturn(projectName);
+    when(trigger.getRepositoryName()).thenReturn(repositoryName);
+    when(trigger.isIgnoreSsl()).thenReturn(false);
+
+    stubFor(
+        get(format(
+                "/rest/api/1.0/projects/%s/repos/%s/pull-requests?start=0",
+                projectName, repositoryName))
+            .willReturn(okJson("{\"isLastPage\": true, \"values\": []}")));
+
+    StashRepository newStashRepository = new StashRepository(project, trigger);
+    assertThat(newStashRepository.getTargetPullRequests(), is(empty()));
+    verify(getRequestedFor(anyUrl()));
   }
 }


### PR DESCRIPTION
```
*  StashRepository: Merge init() into the constructor
   
   Jenkins documentation doesn't guarantee that start() would not be called
   after run() for a trigger.
   
   While it doesn't happen in freestyle projects, Jenkins would actually
   call start() after run() on the trigger in a pipeline project.
   
   That would create a new StashRepository object that would not have the
   StashApiClient object initialized. When the build completes, it would try
   to post the build result as a PR comment. That would throw an exception.
   
   To prevent it, remove the init() method. Move StashApiClient
   initialization inside the StashRepository constructor, so that the
   StashRepository object always has a valid StashApiClient object.
   
   Add WireMock as a test dependency. Check that the newly constructed
   StashRepository object would actually send an HTTP request.
```

That's one of the commits that make pipeline support possible. Extracted from #69 to help with review.

I realize that constructors are less testable than other methods, but the focus here is on fixing an issue with pipelines with minimal changes.

In the future, we can use factory pattern or generics to improve testability. Also, it might be possible not to replace the `StashRepository` object on the `start()` call for the same job. I'm not doing any optimization at this time, I'm making the code more robust.