### PR TITLE
Clean up exception handling in StashApiClient

### DIFF
--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepositoryTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepositoryTest.java
@@ -10,6 +10,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyArray;
@@ -17,6 +18,7 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -312,6 +314,16 @@ public class StashRepositoryTest {
   }
 
   @Test
+  public void getTargetPullRequests_skips_if_getPullRequestMergeStatus_throws() throws Exception {
+    when(stashApiClient.getPullRequests()).thenReturn(pullRequestList);
+    when(trigger.getCheckProbeMergeStatus()).thenReturn(true);
+    when(stashApiClient.getPullRequestMergeStatus(pullRequest.getId()))
+        .thenThrow(new StashApiException("Unknown Status"));
+
+    assertThat(stashRepository.getTargetPullRequests(), is(empty()));
+  }
+
+  @Test
   public void getAdditionalParameters_uses_newest_parameter_definition() throws Exception {
     StashPullRequestComment comment1 = new StashPullRequestComment();
     comment1.setCommentId(1);
@@ -376,6 +388,43 @@ public class StashRepositoryTest {
 
     verify(stashApiClient, times(1)).deletePullRequestComment(eq("123"), eq("1"));
     verify(stashApiClient, times(0)).deletePullRequestComment(eq("123"), eq("2"));
+  }
+
+  @Test
+  public void addFutureBuildTasks_schedules_build_if_deletePullRequestComment_throws()
+      throws Exception {
+    StashPullRequestComment comment = new StashPullRequestComment();
+    comment.setCommentId(1);
+    comment.setText("[*BuildFinished* **MyProject**] DEF2 into DEF1");
+    List<StashPullRequestComment> comments = Arrays.asList(comment);
+
+    StashPullRequestComment response = new StashPullRequestComment();
+    response.setCommentId(2);
+
+    when(stashApiClient.getPullRequestComments(any(), any(), any())).thenReturn(comments);
+    when(stashApiClient.postPullRequestComment(any(), any())).thenReturn(response);
+
+    when(trigger.getDeletePreviousBuildFinishComments()).thenReturn(true);
+    when(trigger.getStashHost()).thenReturn("http://localhost/");
+    when(project.getDisplayName()).thenReturn("MyProject");
+    doThrow(new StashApiException("Cannot Delete"))
+        .when(stashApiClient)
+        .deletePullRequestComment(any(), any());
+
+    stashRepository.addFutureBuildTasks(pullRequestList);
+
+    assertThat(Jenkins.getInstance().getQueue().getItems(), is(arrayWithSize(1)));
+  }
+
+  @Test
+  public void addFutureBuildTasks_doesnt_schedule_build_if_postPullRequestComment_throws()
+      throws Exception {
+    when(stashApiClient.postPullRequestComment(any(), any()))
+        .thenThrow(new StashApiException("Cannot Post"));
+
+    stashRepository.addFutureBuildTasks(pullRequestList);
+
+    assertThat(Jenkins.getInstance().getQueue().getItems(), is(emptyArray()));
   }
 
   @Test

--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClientTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClientTest.java
@@ -1,14 +1,118 @@
 package stashpullrequestbuilder.stashpullrequestbuilder.stash;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.absent;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.delete;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.noContent;
+import static com.github.tomakehurst.wiremock.client.WireMock.notFound;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
+import com.github.tomakehurst.wiremock.client.BasicCredentials;
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.http.Fault;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import org.codehaus.jackson.JsonParseException;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashApiClient.StashApiException;
+
+/*
+ * Known issues:
+ *
+ * RuntimeException is thrown, but the callers may not be prepared for it, as it's not a checked exception
+ * Many calls ignore HTTP errors, especially "malformed response"
+ * deletePullRequestComment() gives no indication whether the call has succeeded
+ * mergePullRequest() throws on 409 Conflict instead of returning false as apparently intended
+ * There are no checks whether the HTTP code indicates an error for the specific request
+ * POST requests throw on 204 No Content
+ * Timeouts are not testable without very slow tests, as the timings are not configurable
+ */
 
 /** Created by nathan on 7/06/2015. */
 public class StashApiClientTest {
+
+  @Rule public ExpectedException expectedException = ExpectedException.none();
+  @Rule public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicHttpsPort());
+
+  private StashApiClient client;
+
+  private String projectName = "PROJ";
+  private String repositoryName = "Repo";
+  private String pullRequestId = "1337";
+  private String commentId = "42";
+  private String mergeVersion = "12345";
+
+  @Before
+  public void before() throws Exception {
+    client =
+        new StashApiClient(
+            wireMockRule.baseUrl(), "Username", "Password", projectName, repositoryName, true);
+  }
+
+  private String pullRequestPath(int start) {
+    return format(
+        "/rest/api/1.0/projects/%s/repos/%s/pull-requests?start=%d",
+        projectName, repositoryName, start);
+  }
+
+  private String pullRequestActivitiesPath(int start) {
+    return format(
+        "/rest/api/1.0/projects/%s/repos/%s/pull-requests/%s/activities?start=%d",
+        projectName, repositoryName, pullRequestId, start);
+  }
+
+  private String pullRequestCommentPath(String commentId) {
+    return format(
+        "/rest/api/1.0/projects/%s/repos/%s/pull-requests/%s/comments/%s?version=0",
+        projectName, repositoryName, pullRequestId, commentId);
+  }
+
+  private String pullRequestPostCommentPath() {
+    return format(
+        "/rest/api/1.0/projects/%s/repos/%s/pull-requests/%s/comments",
+        projectName, repositoryName, pullRequestId);
+  }
+
+  private String pullRequestMergeStatusPath() {
+    return format(
+        "/rest/api/1.0/projects/%s/repos/%s/pull-requests/%s/merge",
+        projectName, repositoryName, pullRequestId);
+  }
+
+  private String pullRequestMergePath(String version) {
+    return format(
+        "/rest/api/1.0/projects/%s/repos/%s/pull-requests/%s/merge?version=%s",
+        projectName, repositoryName, pullRequestId, version);
+  }
+
+  private ResponseDefinitionBuilder jsonResponse(String filename) {
+    return aResponse()
+        .withStatus(200)
+        .withBodyFile(filename)
+        .withHeader("Content-Type", "application/json");
+  }
 
   @Test
   public void testParsePullRequestMergeStatus() throws Exception {
@@ -19,5 +123,318 @@ public class StashApiClientTest {
     assertThat(resp.getCanMerge(), is(false));
     assertThat(resp.getConflicted(), is(false));
     assertThat(resp.getVetoes(), hasSize(1));
+  }
+
+  @Test
+  public void getPullRequests_gets_empty_list() throws Exception {
+    stubFor(get(pullRequestPath(0)).willReturn(jsonResponse("PullRequestListEmpty.json")));
+
+    assertThat(client.getPullRequests(), is(empty()));
+  }
+
+  @Test
+  public void getPullRequests_gets_pull_requests_from_multiple_pages() throws Exception {
+    stubFor(get(pullRequestPath(0)).willReturn(jsonResponse("PullRequestListPage1.json")));
+    stubFor(get(pullRequestPath(4)).willReturn(jsonResponse("PullRequestListPage2.json")));
+    stubFor(get(pullRequestPath(8)).willReturn(jsonResponse("PullRequestListPage3.json")));
+
+    List<StashPullRequestResponseValue> pullRequests = client.getPullRequests();
+    assertThat(pullRequests, hasSize(11)); // 4 + 4 + 3
+    assertThat(pullRequests.get(0).getTitle(), is("First PR"));
+    assertThat(pullRequests.get(10).getTitle(), is("Last PR"));
+  }
+
+  @Test
+  public void getPullRequests_throws_on_not_found() throws Exception {
+    stubFor(any(anyUrl()).willReturn(notFound()));
+
+    expectedException.expect(RuntimeException.class);
+    expectedException.expectMessage(containsString("Didn't get a 200 response from Stash PR GET"));
+    expectedException.expectCause(is(instanceOf(ExecutionException.class)));
+
+    client.getPullRequests();
+  }
+
+  @Test
+  public void getPullRequests_throws_on_malformed_response() throws Exception {
+    stubFor(any(anyUrl()).willReturn(aResponse().withFault(Fault.MALFORMED_RESPONSE_CHUNK)));
+
+    expectedException.expect(StashApiException.class);
+    expectedException.expectMessage(containsString("Cannot read list of pull requests"));
+    expectedException.expectCause(is(instanceOf(JsonParseException.class)));
+
+    client.getPullRequests();
+  }
+
+  @Test
+  public void getPullRequests_throws_on_connection_reset() throws Exception {
+    stubFor(any(anyUrl()).willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
+
+    expectedException.expect(RuntimeException.class);
+    expectedException.expectMessage(containsString("Connection reset"));
+    expectedException.expectCause(is(instanceOf(ExecutionException.class)));
+
+    client.getPullRequests();
+  }
+
+  @Test
+  public void getPullRequestComments_gets_empty_list() throws Exception {
+    stubFor(
+        get(pullRequestActivitiesPath(0))
+            .willReturn(jsonResponse("PullRequestCommentsEmpty.json")));
+
+    assertThat(
+        client.getPullRequestComments(projectName, repositoryName, pullRequestId), is(empty()));
+  }
+
+  @Test
+  public void getPullRequestComments_gets_pull_requests_from_multiple_pages() throws Exception {
+    stubFor(
+        get(pullRequestActivitiesPath(0))
+            .willReturn(jsonResponse("PullRequestCommentsPage1.json")));
+    stubFor(
+        get(pullRequestActivitiesPath(4))
+            .willReturn(jsonResponse("PullRequestCommentsPage2.json")));
+    stubFor(
+        get(pullRequestActivitiesPath(8))
+            .willReturn(jsonResponse("PullRequestCommentsPage3.json")));
+
+    List<StashPullRequestComment> comments =
+        client.getPullRequestComments(projectName, repositoryName, pullRequestId);
+    assertThat(comments, hasSize(10)); // 4 + 4 + 2, not counting a broken comment
+    assertThat(comments.get(0).getText(), is("First comment"));
+    assertThat(comments.get(9).getText(), is("Last comment"));
+  }
+
+  @Test
+  public void getPullRequestComments_throws_on_not_found() throws Exception {
+    stubFor(any(anyUrl()).willReturn(notFound()));
+
+    expectedException.expect(StashApiException.class);
+    expectedException.expectMessage(containsString("cannot read comments for pull request"));
+    expectedException.expectCause(is(instanceOf(RuntimeException.class)));
+
+    client.getPullRequestComments(projectName, repositoryName, pullRequestId);
+  }
+
+  @Test
+  public void getPullRequestComments_throws_on_malformed_response() throws Exception {
+    stubFor(any(anyUrl()).willReturn(aResponse().withFault(Fault.MALFORMED_RESPONSE_CHUNK)));
+
+    expectedException.expect(StashApiException.class);
+    expectedException.expectMessage(containsString("cannot read comments for pull request"));
+    expectedException.expectCause(is(instanceOf(JsonParseException.class)));
+
+    client.getPullRequestComments(projectName, repositoryName, pullRequestId);
+  }
+
+  @Test
+  public void getPullRequestComments_throws_on_connection_reset() throws Exception {
+    stubFor(any(anyUrl()).willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
+
+    expectedException.expect(StashApiException.class);
+    expectedException.expectMessage(containsString("cannot read comments for pull request"));
+    expectedException.expectCause(is(instanceOf(RuntimeException.class)));
+
+    client.getPullRequestComments(projectName, repositoryName, pullRequestId);
+  }
+
+  @Test
+  public void deletePullRequestComment_deletes_comment() throws Exception {
+    stubFor(delete(pullRequestCommentPath(commentId)).willReturn(noContent()));
+
+    client.deletePullRequestComment(pullRequestId, commentId);
+  }
+
+  @Test
+  public void deletePullRequestComment_doesnt_throw_on_not_found() throws Exception {
+    stubFor(any(anyUrl()).willReturn(notFound()));
+
+    client.deletePullRequestComment(pullRequestId, commentId);
+  }
+
+  @Test
+  public void deletePullRequestComment_doesnt_throw_on_malformed_response() throws Exception {
+    stubFor(any(anyUrl()).willReturn(aResponse().withFault(Fault.MALFORMED_RESPONSE_CHUNK)));
+
+    client.deletePullRequestComment(pullRequestId, commentId);
+  }
+
+  @Test
+  public void deletePullRequestComment_throws_on_connection_reset() throws Exception {
+    stubFor(any(anyUrl()).willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
+
+    expectedException.expect(RuntimeException.class);
+    expectedException.expectMessage(containsString("Connection reset"));
+    expectedException.expectCause(is(instanceOf(ExecutionException.class)));
+
+    client.deletePullRequestComment(pullRequestId, commentId);
+  }
+
+  @Test
+  public void postPullRequestComment_posts_comment() throws Exception {
+    stubFor(
+        post(pullRequestPostCommentPath())
+            .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
+            .willReturn(jsonResponse("PostPullRequestComment.json")));
+
+    StashPullRequestComment comment = client.postPullRequestComment(pullRequestId, "Some comment");
+    assertThat(comment.getCommentId(), is(234));
+    assertThat(comment.getText(), is("Build started"));
+
+    verify(
+        postRequestedFor(anyUrl())
+            .withBasicAuth(new BasicCredentials("Username", "Password"))
+            .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
+            .withHeader("Connection", equalTo("close"))
+            .withHeader("X-Atlassian-Token", equalTo("no-check"))
+            .withRequestBody(equalToJson("{\"text\":\"Some comment\"}")));
+  }
+
+  @Test
+  public void postPullRequestComment_throws_on_no_content() throws Exception {
+    stubFor(post(pullRequestPostCommentPath()).willReturn(noContent()));
+
+    expectedException.expect(RuntimeException.class);
+    expectedException.expectMessage(containsString("NullPointerException"));
+    expectedException.expectCause(is(instanceOf(ExecutionException.class)));
+
+    client.postPullRequestComment(pullRequestId, "Some comment");
+  }
+
+  @Test
+  public void postPullRequestComment_throws_on_not_found() throws Exception {
+    stubFor(any(anyUrl()).willReturn(notFound()));
+
+    expectedException.expect(RuntimeException.class);
+    expectedException.expectMessage(containsString("Didn't get a 200 response from Stash PR POST"));
+    expectedException.expectCause(is(instanceOf(ExecutionException.class)));
+
+    client.postPullRequestComment(pullRequestId, "Some comment");
+  }
+
+  @Test
+  public void postPullRequestComment_doesnt_throw_on_malformed_response() throws Exception {
+    stubFor(any(anyUrl()).willReturn(aResponse().withFault(Fault.MALFORMED_RESPONSE_CHUNK)));
+
+    client.postPullRequestComment(pullRequestId, "Some comment");
+  }
+
+  @Test
+  public void postPullRequestComment_throws_on_connection_reset() throws Exception {
+    stubFor(any(anyUrl()).willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
+
+    expectedException.expect(RuntimeException.class);
+    expectedException.expectMessage(containsString("Connection reset"));
+    expectedException.expectCause(is(instanceOf(ExecutionException.class)));
+
+    client.postPullRequestComment(pullRequestId, "Some comment");
+  }
+
+  @Test
+  public void getPullRequestMergeStatus_gets_merge_status() throws Exception {
+    stubFor(
+        get(pullRequestMergeStatusPath()).willReturn(jsonResponse("PullRequestMergeStatus.json")));
+
+    StashPullRequestMergeableResponse resp = client.getPullRequestMergeStatus(pullRequestId);
+    assertThat(resp, is(notNullValue()));
+    assertThat(resp.getCanMerge(), is(true));
+    assertThat(resp.getConflicted(), is(true));
+    assertThat(resp.getVetoes(), hasSize(2));
+  }
+
+  @Test
+  public void getPullRequestMergeStatus_throws_on_not_found() throws Exception {
+    stubFor(any(anyUrl()).willReturn(notFound()));
+
+    expectedException.expect(RuntimeException.class);
+    expectedException.expectMessage(containsString("Didn't get a 200 response from Stash PR GET"));
+    expectedException.expectCause(is(instanceOf(ExecutionException.class)));
+
+    client.getPullRequestMergeStatus(pullRequestId);
+  }
+
+  @Test
+  public void getPullRequestMergeStatus_doesnt_throw_on_malformed_response() throws Exception {
+    stubFor(any(anyUrl()).willReturn(aResponse().withFault(Fault.MALFORMED_RESPONSE_CHUNK)));
+
+    client.getPullRequestMergeStatus(pullRequestId);
+  }
+
+  @Test
+  public void getPullRequestMergeStatus_throws_on_connection_reset() throws Exception {
+    stubFor(any(anyUrl()).willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
+
+    expectedException.expect(RuntimeException.class);
+    expectedException.expectMessage(containsString("Connection reset"));
+    expectedException.expectCause(is(instanceOf(ExecutionException.class)));
+
+    client.getPullRequestMergeStatus(pullRequestId);
+  }
+
+  @Test
+  public void mergePullRequest_sends_merge_request() throws Exception {
+    stubFor(post(pullRequestMergePath(mergeVersion)).willReturn(okJson("{}")));
+
+    assertThat(client.mergePullRequest(pullRequestId, mergeVersion), is(true));
+
+    verify(
+        postRequestedFor(anyUrl())
+            .withBasicAuth(new BasicCredentials("Username", "Password"))
+            .withHeader("Content-Type", absent())
+            .withHeader("Connection", equalTo("close"))
+            .withHeader("X-Atlassian-Token", equalTo("no-check"))
+            .withRequestBody(equalTo("")));
+  }
+
+  @Test
+  public void mergePullRequest_throws_on_empty_response() throws Exception {
+    stubFor(post(pullRequestMergePath(mergeVersion)).willReturn(noContent()));
+
+    expectedException.expect(RuntimeException.class);
+    expectedException.expectMessage(containsString("NullPointerException"));
+    expectedException.expectCause(is(instanceOf(ExecutionException.class)));
+
+    assertThat(client.mergePullRequest(pullRequestId, mergeVersion), is(true));
+  }
+
+  @Test
+  public void mergePullRequest_throws_on_conflict() throws Exception {
+    stubFor(any(anyUrl()).willReturn(aResponse().withStatus(409)));
+
+    expectedException.expect(RuntimeException.class);
+    expectedException.expectMessage(containsString("Didn't get a 200 response from Stash PR POST"));
+    expectedException.expectCause(is(instanceOf(ExecutionException.class)));
+
+    client.mergePullRequest(pullRequestId, mergeVersion);
+  }
+
+  @Test
+  public void mergePullRequest_throws_on_not_found() throws Exception {
+    stubFor(any(anyUrl()).willReturn(notFound()));
+
+    expectedException.expect(RuntimeException.class);
+    expectedException.expectMessage(containsString("Didn't get a 200 response from Stash PR POST"));
+    expectedException.expectCause(is(instanceOf(ExecutionException.class)));
+
+    client.mergePullRequest(pullRequestId, mergeVersion);
+  }
+
+  @Test
+  public void mergePullRequest_doesnt_throw_on_malformed_response() throws Exception {
+    stubFor(any(anyUrl()).willReturn(aResponse().withFault(Fault.MALFORMED_RESPONSE_CHUNK)));
+
+    client.mergePullRequest(pullRequestId, mergeVersion);
+  }
+
+  @Test
+  public void mergePullRequest_throws_on_connection_reset() throws Exception {
+    stubFor(any(anyUrl()).willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
+
+    expectedException.expect(RuntimeException.class);
+    expectedException.expectMessage(containsString("Connection reset"));
+    expectedException.expectCause(is(instanceOf(ExecutionException.class)));
+
+    client.mergePullRequest(pullRequestId, mergeVersion);
   }
 }

--- a/src/test/resources/__files/PostPullRequestComment.json
+++ b/src/test/resources/__files/PostPullRequestComment.json
@@ -1,0 +1,4 @@
+{
+  "id" : 234,
+  "text" : "Build started"
+}

--- a/src/test/resources/__files/PullRequestCommentsEmpty.json
+++ b/src/test/resources/__files/PullRequestCommentsEmpty.json
@@ -1,0 +1,4 @@
+{
+  "isLastPage" : true,
+  "values" : []
+}

--- a/src/test/resources/__files/PullRequestCommentsPage1.json
+++ b/src/test/resources/__files/PullRequestCommentsPage1.json
@@ -1,0 +1,21 @@
+{
+  "isLastPage" : false,
+  "nextPageStart" : 4,
+  "values" : [
+    {
+      "comment" : {
+        "id" : 0,
+        "text" : "First comment"
+      }
+    },
+    {
+      "comment" : {}
+    },
+    {
+      "comment" : {}
+    },
+    {
+      "comment" : {}
+    }
+  ]
+}

--- a/src/test/resources/__files/PullRequestCommentsPage2.json
+++ b/src/test/resources/__files/PullRequestCommentsPage2.json
@@ -1,0 +1,18 @@
+{
+  "isLastPage" : false,
+  "nextPageStart" : 8,
+  "values" : [
+    {
+      "comment" : {}
+    },
+    {
+      "comment" : {}
+    },
+    {
+      "comment" : {}
+    },
+    {
+      "comment" : {}
+    }
+  ]
+}

--- a/src/test/resources/__files/PullRequestCommentsPage3.json
+++ b/src/test/resources/__files/PullRequestCommentsPage3.json
@@ -1,0 +1,17 @@
+{
+  "isLastPage" : true,
+  "values" : [
+    {
+      "comment" : {}
+    },
+    {
+      "comment" : {
+        "id" : 9,
+        "text" : "Last comment"
+      }
+    },
+    {
+      "broken_comment" : {}
+    }
+  ]
+}

--- a/src/test/resources/__files/PullRequestListEmpty.json
+++ b/src/test/resources/__files/PullRequestListEmpty.json
@@ -1,0 +1,4 @@
+{
+  "isLastPage" : true,
+  "values" : []
+}

--- a/src/test/resources/__files/PullRequestListPage1.json
+++ b/src/test/resources/__files/PullRequestListPage1.json
@@ -1,0 +1,12 @@
+{
+  "isLastPage" : false,
+  "nextPageStart" : 4,
+  "values" : [
+    {
+      "title" : "First PR"
+    },
+    {},
+    {},
+    {}
+  ]
+}

--- a/src/test/resources/__files/PullRequestListPage2.json
+++ b/src/test/resources/__files/PullRequestListPage2.json
@@ -1,0 +1,10 @@
+{
+  "isLastPage" : false,
+  "nextPageStart" : 8,
+  "values" : [
+    {},
+    {},
+    {},
+    {}
+  ]
+}

--- a/src/test/resources/__files/PullRequestListPage3.json
+++ b/src/test/resources/__files/PullRequestListPage3.json
@@ -1,0 +1,10 @@
+{
+  "isLastPage" : true,
+  "values" : [
+    {},
+    {},
+    {
+      "title" : "Last PR"
+    }
+  ]
+}

--- a/src/test/resources/__files/PullRequestMergeStatus.json
+++ b/src/test/resources/__files/PullRequestMergeStatus.json
@@ -1,0 +1,8 @@
+{
+  "canMerge" : true,
+  "conflicted" : true,
+  "vetoes" : [
+    {},
+    {}
+  ]
+}


### PR DESCRIPTION
The first commit adds WireMock based unit tests for the entire `StashApiClient.java`. In some cases, the tests indicate issues in the code under test. Those issues are documented.

The second commit changed exception handling in StashApiClient. Only specific checked exceptions are used, `RuntimeException` and `Exception` are banned. The callers are changes to handle the exceptions. That code was getting `RuntimeException` and ignored it. Now it's forces to deal with it properly.