### PR TITLE
StashBuildTrigger: Use correct getter names for config.jelly fields

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -117,7 +117,7 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
   }
 
   // Needed for Jelly Config
-  public String getcredentialsId() {
+  public String getCredentialsId() {
     return this.credentialsId;
   }
 
@@ -162,7 +162,7 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
     return checkDestinationCommit;
   }
 
-  public boolean isIgnoreSsl() {
+  public boolean getIgnoreSsl() {
     return ignoreSsl;
   }
 
@@ -178,7 +178,7 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
     return mergeOnSuccess;
   }
 
-  public boolean isCancelOutdatedJobsEnabled() {
+  public boolean getCancelOutdatedJobsEnabled() {
     return cancelOutdatedJobsEnabled;
   }
 
@@ -220,19 +220,19 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
     super.stop();
   }
 
-  public boolean isCheckMergeable() {
+  public boolean getCheckMergeable() {
     return checkMergeable;
   }
 
-  public boolean isCheckNotConflicted() {
+  public boolean getCheckNotConflicted() {
     return checkNotConflicted;
   }
 
-  public boolean isCheckProbeMergeStatus() {
+  public boolean getCheckProbeMergeStatus() {
     return checkProbeMergeStatus;
   }
 
-  public boolean isOnlyBuildOnComment() {
+  public boolean getOnlyBuildOnComment() {
     return onlyBuildOnComment;
   }
 

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -86,7 +86,7 @@ public class StashRepository {
         trigger.getPassword(),
         trigger.getProjectCode(),
         trigger.getRepositoryName(),
-        trigger.isIgnoreSsl());
+        trigger.getIgnoreSsl());
   }
 
   public Collection<StashPullRequestResponseValue> getTargetPullRequests() {
@@ -256,7 +256,7 @@ public class StashRepository {
   public Queue.Item startJob(StashCause cause) {
     List<ParameterValue> values = getParameters(cause);
 
-    if (trigger.isCancelOutdatedJobsEnabled()) {
+    if (trigger.getCancelOutdatedJobsEnabled()) {
       cancelPreviousJobsInQueueThatMatch(cause);
       abortRunningJobsThatMatch(cause);
     }
@@ -367,9 +367,9 @@ public class StashRepository {
   }
 
   private boolean isPullRequestMergeable(StashPullRequestResponseValue pullRequest) {
-    if (trigger.isCheckMergeable()
-        || trigger.isCheckNotConflicted()
-        || trigger.isCheckProbeMergeStatus()) {
+    if (trigger.getCheckMergeable()
+        || trigger.getCheckNotConflicted()
+        || trigger.getCheckProbeMergeStatus()) {
       /* Request PR status from Stash, and consult our configuration
        * toggles on whether we care about certain verdicts in that
        * JSON answer, parsed into fields of the "response" object.
@@ -378,11 +378,11 @@ public class StashRepository {
       StashPullRequestMergeableResponse mergeable =
           client.getPullRequestMergeStatus(pullRequest.getId());
       boolean res = true;
-      if (trigger.isCheckMergeable()) {
+      if (trigger.getCheckMergeable()) {
         res &= mergeable.getCanMerge();
       }
 
-      if (trigger.isCheckNotConflicted()) {
+      if (trigger.getCheckNotConflicted()) {
         res &= !mergeable.getConflicted();
       }
 
@@ -459,7 +459,7 @@ public class StashRepository {
       return false;
     }
 
-    boolean isOnlyBuildOnComment = trigger.isOnlyBuildOnComment();
+    boolean isOnlyBuildOnComment = trigger.getOnlyBuildOnComment();
 
     if (isOnlyBuildOnComment) {
       shouldBuild = false;

--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTriggerTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTriggerTest.java
@@ -1,0 +1,56 @@
+package stashpullrequestbuilder.stashpullrequestbuilder;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import hudson.model.Descriptor.PropertyType;
+import java.util.Arrays;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
+import stashpullrequestbuilder.stashpullrequestbuilder.StashBuildTrigger.StashBuildTriggerDescriptor;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StashBuildTriggerTest {
+
+  @Rule public JenkinsRule jenkinsRule = new JenkinsRule();
+  @Rule public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+
+  @Test
+  public void check_getters() throws Exception {
+    StashBuildTriggerDescriptor descriptor = StashBuildTrigger.descriptor;
+
+    // Field names from config.jelly
+    Iterable<String> properties =
+        Arrays.asList(
+            "cron",
+            "stashHost",
+            "credentialsId",
+            "projectCode",
+            "repositoryName",
+            "ignoreSsl",
+            "targetBranchesToBuild",
+            "checkDestinationCommit",
+            "checkNotConflicted",
+            "checkMergeable",
+            "checkProbeMergeStatus",
+            "mergeOnSuccess",
+            "deletePreviousBuildFinishComments",
+            "cancelOutdatedJobsEnabled",
+            "ciSkipPhrases",
+            "onlyBuildOnComment",
+            "ciBuildPhrases");
+
+    for (String property : properties) {
+      System.out.println(property);
+      PropertyType propertyType = descriptor.getPropertyType(property);
+      assertThat(propertyType, is(notNullValue()));
+    }
+  }
+}

--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepositoryTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepositoryTest.java
@@ -516,7 +516,7 @@ public class StashRepositoryTest {
     when(trigger.getPassword()).thenReturn("Password");
     when(trigger.getProjectCode()).thenReturn(projectName);
     when(trigger.getRepositoryName()).thenReturn(repositoryName);
-    when(trigger.isIgnoreSsl()).thenReturn(false);
+    when(trigger.getIgnoreSsl()).thenReturn(false);
 
     stubFor(
         get(format(


### PR DESCRIPTION
Getter names for fields referenced in config.jelly should start with "get" followed by the capitalized property name. "is" is not supported.

That's an alternative to #72 and it has unit tests.

It's not a pipeline only issue and should not be blocked by any other PR. The current code is not following the rule recommended in the Jenkins Wiki.

https://wiki.jenkins.io/display/JENKINS/Basic+guide+to+Jelly+usage+in+Jenkins#BasicguidetoJellyusageinJenkins-Understandingtheitobject