### PR TITLE
StashRepository: Log stack trace when catching StashApiException

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -98,7 +99,7 @@ public class StashRepository {
     try {
       pullRequests = client.getPullRequests();
     } catch (StashApiException e) {
-      logger.info(format("%s: cannot fetch pull request list: %s", job.getName(), e));
+      logger.log(Level.INFO, format("%s: cannot fetch pull request list", job.getName()), e);
       return targetPullRequests;
     }
 
@@ -272,10 +273,12 @@ public class StashRepository {
       try {
         additionalParameters = getAdditionalParameters(pullRequest);
       } catch (StashApiException e) {
-        logger.info(
+        logger.log(
+            Level.INFO,
             format(
-                "%s: cannot read additional parameters for pull request %s, skipping: %s",
-                job.getName(), pullRequest.getId(), e));
+                "%s: cannot read additional parameters for pull request %s, skipping",
+                job.getName(), pullRequest.getId()),
+            e);
         continue;
       }
 
@@ -283,10 +286,12 @@ public class StashRepository {
         try {
           deletePreviousBuildFinishedComments(pullRequest);
         } catch (StashApiException e) {
-          logger.info(
+          logger.log(
+              Level.INFO,
               format(
-                  "%s: cannot delete old \"BuildFinished\" comments for pull request %s: %s",
-                  job.getName(), pullRequest, e));
+                  "%s: cannot delete old \"BuildFinished\" comments for pull request %s",
+                  job.getName(), pullRequest),
+              e);
         }
       }
 
@@ -473,7 +478,7 @@ public class StashRepository {
     try {
       comments = client.getPullRequestComments(owner, repositoryName, id);
     } catch (StashApiException e) {
-      logger.info(format("%s: cannot read pull request comments: %s", job.getName(), e));
+      logger.log(Level.INFO, format("%s: cannot read pull request comments", job.getName()), e);
       return false;
     }
 


### PR DESCRIPTION
This fixes an issue introduced in #93. When `StashApiException` is caught, the exception is used as a `format` argument. That applies `toString()` to the exception, which doesn't include the stack trace.

Instead, use a variant of `logger.log()` that accepts an exception as the last argument and prints the type of the exception, the associated message and the stack trace.