### PR TITLE
StashBuildTrigger: Rename StashBuildTriggerDescriptor to DescriptorImpl

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -55,8 +55,7 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
 
   private transient StashPullRequestsBuilder stashPullRequestsBuilder;
 
-  @Extension
-  public static final StashBuildTriggerDescriptor descriptor = new StashBuildTriggerDescriptor();
+  @Extension public static final DescriptorImpl descriptor = new DescriptorImpl();
 
   @DataBoundConstructor
   public StashBuildTrigger(
@@ -229,8 +228,8 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
     return onlyBuildOnComment;
   }
 
-  public static final class StashBuildTriggerDescriptor extends TriggerDescriptor {
-    public StashBuildTriggerDescriptor() {
+  public static final class DescriptorImpl extends TriggerDescriptor {
+    public DescriptorImpl() {
       load();
     }
 

--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTriggerTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTriggerTest.java
@@ -14,7 +14,6 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.junit.MockitoRule;
 import org.mockito.quality.Strictness;
-import stashpullrequestbuilder.stashpullrequestbuilder.StashBuildTrigger.StashBuildTriggerDescriptor;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StashBuildTriggerTest {
@@ -24,7 +23,7 @@ public class StashBuildTriggerTest {
 
   @Test
   public void check_getters() throws Exception {
-    StashBuildTriggerDescriptor descriptor = StashBuildTrigger.descriptor;
+    StashBuildTrigger.DescriptorImpl descriptor = StashBuildTrigger.descriptor;
 
     // Field names from config.jelly
     Iterable<String> properties =


### PR DESCRIPTION
```
*  StashBuildTrigger: Rename StashBuildTriggerDescriptor to DescriptorImpl
   
   DescriptorImpl is the standard name for a descriptor defined as an inner
   class. StashBuildTriggerDescriptor is a long name that duplicates the
   name of its containing class, StashBuildTrigger.
```

Actually, `StashPostBuildComment.java` uses `DescriptorImpl`, so the plugin code is inconsistent. Let's make it consistent.

The descriptor name is written to the XML file that holds the global configuration of the plugin. That's where the option to enable pipelines would go. That's why I want this PR to be merged before #69 so that we don't deal with backward compatibility later.