### PR TITLE
Make some settings optional in pipelines

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -34,24 +34,27 @@ import org.kohsuke.stapler.StaplerRequest;
 public class StashBuildTrigger extends Trigger<Job<?, ?>> {
   private static final Logger logger =
       Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
+
+  // Required settings
   private final String cron;
   private final String stashHost;
   private final String credentialsId;
   private final String projectCode;
   private final String repositoryName;
-  private final String ciSkipPhrases;
-  private final String ciBuildPhrases;
-  private final String targetBranchesToBuild;
-  private final boolean ignoreSsl;
-  private final boolean checkDestinationCommit;
-  private final boolean checkMergeable;
-  private final boolean mergeOnSuccess;
-  private final boolean checkNotConflicted;
-  private final boolean onlyBuildOnComment;
-  private final boolean deletePreviousBuildFinishComments;
-  private final boolean cancelOutdatedJobsEnabled;
 
+  // Optional settings
+  private boolean ignoreSsl;
+  private String targetBranchesToBuild;
+  private boolean checkDestinationCommit;
+  private boolean checkNotConflicted;
+  private boolean checkMergeable;
   private boolean checkProbeMergeStatus;
+  private boolean mergeOnSuccess;
+  private boolean deletePreviousBuildFinishComments;
+  private boolean cancelOutdatedJobsEnabled;
+  private String ciSkipPhrases;
+  private boolean onlyBuildOnComment;
+  private String ciBuildPhrases;
 
   private transient StashPullRequestsBuilder stashPullRequestsBuilder;
 
@@ -63,18 +66,7 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
       String stashHost,
       String credentialsId,
       String projectCode,
-      String repositoryName,
-      String ciSkipPhrases,
-      boolean ignoreSsl,
-      boolean checkDestinationCommit,
-      boolean checkMergeable,
-      boolean mergeOnSuccess,
-      boolean checkNotConflicted,
-      boolean onlyBuildOnComment,
-      String ciBuildPhrases,
-      boolean deletePreviousBuildFinishComments,
-      String targetBranchesToBuild,
-      boolean cancelOutdatedJobsEnabled)
+      String repositoryName)
       throws ANTLRException {
     super(cron);
     this.cron = cron;
@@ -82,33 +74,16 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
     this.credentialsId = credentialsId;
     this.projectCode = projectCode;
     this.repositoryName = repositoryName;
-    this.ciSkipPhrases = ciSkipPhrases;
-    this.cancelOutdatedJobsEnabled = cancelOutdatedJobsEnabled;
-    this.ciBuildPhrases = ciBuildPhrases == null ? "test this please" : ciBuildPhrases;
-    this.ignoreSsl = ignoreSsl;
-    this.checkDestinationCommit = checkDestinationCommit;
-    this.checkMergeable = checkMergeable;
-    this.mergeOnSuccess = mergeOnSuccess;
-    this.checkNotConflicted = checkNotConflicted;
-    this.onlyBuildOnComment = onlyBuildOnComment;
-    this.deletePreviousBuildFinishComments = deletePreviousBuildFinishComments;
-    this.targetBranchesToBuild = targetBranchesToBuild;
-  }
-
-  @DataBoundSetter
-  public void setCheckProbeMergeStatus(boolean checkProbeMergeStatus) {
-    this.checkProbeMergeStatus = checkProbeMergeStatus;
-  }
-
-  public String getStashHost() {
-    return stashHost;
   }
 
   public String getCron() {
     return this.cron;
   }
 
-  // Needed for Jelly Config
+  public String getStashHost() {
+    return stashHost;
+  }
+
   public String getCredentialsId() {
     return this.credentialsId;
   }
@@ -142,36 +117,112 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
     return repositoryName;
   }
 
-  public String getCiSkipPhrases() {
-    return ciSkipPhrases;
-  }
-
-  public String getCiBuildPhrases() {
-    return ciBuildPhrases == null ? "test this please" : ciBuildPhrases;
-  }
-
-  public boolean getCheckDestinationCommit() {
-    return checkDestinationCommit;
-  }
-
   public boolean getIgnoreSsl() {
     return ignoreSsl;
   }
 
-  public boolean getDeletePreviousBuildFinishComments() {
-    return deletePreviousBuildFinishComments;
+  @DataBoundSetter
+  public void setIgnoreSsl(boolean ignoreSsl) {
+    this.ignoreSsl = ignoreSsl;
   }
 
   public String getTargetBranchesToBuild() {
     return targetBranchesToBuild;
   }
 
+  @DataBoundSetter
+  public void setTargetBranchesToBuild(String targetBranchesToBuild) {
+    this.targetBranchesToBuild = targetBranchesToBuild;
+  }
+
+  public boolean getCheckDestinationCommit() {
+    return checkDestinationCommit;
+  }
+
+  @DataBoundSetter
+  public void setCheckDestinationCommit(boolean checkDestinationCommit) {
+    this.checkDestinationCommit = checkDestinationCommit;
+  }
+
+  public boolean getCheckNotConflicted() {
+    return checkNotConflicted;
+  }
+
+  @DataBoundSetter
+  public void setCheckNotConflicted(boolean checkNotConflicted) {
+    this.checkNotConflicted = checkNotConflicted;
+  }
+
+  public boolean getCheckMergeable() {
+    return checkMergeable;
+  }
+
+  @DataBoundSetter
+  public void setCheckMergeable(boolean checkMergeable) {
+    this.checkMergeable = checkMergeable;
+  }
+
+  public boolean getCheckProbeMergeStatus() {
+    return checkProbeMergeStatus;
+  }
+
+  @DataBoundSetter
+  public void setCheckProbeMergeStatus(boolean checkProbeMergeStatus) {
+    this.checkProbeMergeStatus = checkProbeMergeStatus;
+  }
+
   public boolean getMergeOnSuccess() {
     return mergeOnSuccess;
   }
 
+  @DataBoundSetter
+  public void setMergeOnSuccess(boolean mergeOnSuccess) {
+    this.mergeOnSuccess = mergeOnSuccess;
+  }
+
+  public boolean getDeletePreviousBuildFinishComments() {
+    return deletePreviousBuildFinishComments;
+  }
+
+  @DataBoundSetter
+  public void setDeletePreviousBuildFinishComments(boolean deletePreviousBuildFinishComments) {
+    this.deletePreviousBuildFinishComments = deletePreviousBuildFinishComments;
+  }
+
   public boolean getCancelOutdatedJobsEnabled() {
     return cancelOutdatedJobsEnabled;
+  }
+
+  @DataBoundSetter
+  public void setCancelOutdatedJobsEnabled(boolean cancelOutdatedJobsEnabled) {
+    this.cancelOutdatedJobsEnabled = cancelOutdatedJobsEnabled;
+  }
+
+  public String getCiSkipPhrases() {
+    return ciSkipPhrases;
+  }
+
+  @DataBoundSetter
+  public void setCiSkipPhrases(String ciSkipPhrases) {
+    this.ciSkipPhrases = ciSkipPhrases;
+  }
+
+  public boolean getOnlyBuildOnComment() {
+    return onlyBuildOnComment;
+  }
+
+  @DataBoundSetter
+  public void setOnlyBuildOnComment(boolean onlyBuildOnComment) {
+    this.onlyBuildOnComment = onlyBuildOnComment;
+  }
+
+  public String getCiBuildPhrases() {
+    return ciBuildPhrases == null ? "test this please" : ciBuildPhrases;
+  }
+
+  @DataBoundSetter
+  public void setCiBuildPhrases(String ciBuildPhrases) {
+    this.ciBuildPhrases = ciBuildPhrases;
   }
 
   @Override
@@ -210,22 +261,6 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
   public void stop() {
     stashPullRequestsBuilder = null;
     super.stop();
-  }
-
-  public boolean getCheckMergeable() {
-    return checkMergeable;
-  }
-
-  public boolean getCheckNotConflicted() {
-    return checkNotConflicted;
-  }
-
-  public boolean getCheckProbeMergeStatus() {
-    return checkProbeMergeStatus;
-  }
-
-  public boolean getOnlyBuildOnComment() {
-    return onlyBuildOnComment;
   }
 
   public static final class DescriptorImpl extends TriggerDescriptor {

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -44,17 +44,17 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
 
   // Optional settings
   private boolean ignoreSsl;
-  private String targetBranchesToBuild;
+  private String targetBranchesToBuild = "";
   private boolean checkDestinationCommit;
   private boolean checkNotConflicted;
   private boolean checkMergeable;
-  private boolean checkProbeMergeStatus;
+  private boolean checkProbeMergeStatus = true;
   private boolean mergeOnSuccess;
   private boolean deletePreviousBuildFinishComments;
   private boolean cancelOutdatedJobsEnabled;
-  private String ciSkipPhrases;
+  private String ciSkipPhrases = DescriptorImpl.DEFAULT_CI_SKIP_PHRASES;
   private boolean onlyBuildOnComment;
-  private String ciBuildPhrases;
+  private String ciBuildPhrases = DescriptorImpl.DEFAULT_CI_BUILD_PHRASES;
 
   private transient StashPullRequestsBuilder stashPullRequestsBuilder;
 
@@ -217,7 +217,7 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
   }
 
   public String getCiBuildPhrases() {
-    return ciBuildPhrases == null ? "test this please" : ciBuildPhrases;
+    return ciBuildPhrases;
   }
 
   @DataBoundSetter
@@ -264,6 +264,9 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
   }
 
   public static final class DescriptorImpl extends TriggerDescriptor {
+    public static final String DEFAULT_CI_SKIP_PHRASES = "NO TEST";
+    public static final String DEFAULT_CI_BUILD_PHRASES = "test this please";
+
     public DescriptorImpl() {
       load();
     }

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger/config.jelly
@@ -44,13 +44,13 @@
       <f:checkbox default="false"/>
     </f:entry>
     <f:entry title="Phrase to disable builds" field="ciSkipPhrases">
-      <f:textbox default="NO TEST" />
+      <f:textbox default="${descriptor.DEFAULT_CI_SKIP_PHRASES}"/>
     </f:entry>
     <f:entry title="Only build if asked with the build phrase" field="onlyBuildOnComment">
       <f:checkbox default="false"/>
     </f:entry>
     <f:entry title="Phrase to request a (re-)build" field="ciBuildPhrases">
-      <f:textbox default="test this please"/>
+      <f:textbox default="${descriptor.DEFAULT_CI_BUILD_PHRASES}"/>
     </f:entry>
   </f:advanced>
 </j:jelly>


### PR DESCRIPTION
All advanced settings have reasonable defaults so they can be optional settings. Move then from `@DataBoundConstructor` to individual setters.

Make `StashBuildTrigger` initialize fields to the `config.jelly` defaults. That way, the Pipeline Snippet Generator knows what the defaults are and skips them from the snippets.

A nice side effect is having `test this please` and `NO TEST` shared between the code and `config.jelly`.

This PR is based on top of #69, as it's untestable without pipeline support.

The changes are based on https://jenkins.io/doc/developer/plugin-development/pipeline-integration/