### PR TITLE
pom.xml: Use Apache HttpComponents Client 4.x API Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This plugin was inspired by the GitHub & BitBucket pull request builder plugins.
 
 ## Prerequisites
 
-- Jenkins 2.60.1 or higher.
+- Jenkins 2.60.3 or higher.
 - [Git Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin)
 
 ## Environment variables

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
     <revision>1.11</revision>
     <changelist>-SNAPSHOT</changelist>
     <java.level>8</java.level>
+    <jenkins.version>2.60.3</jenkins.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -82,9 +82,9 @@
       <version>2.1.5</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.5.2</version>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>apache-httpcomponents-client-4-api</artifactId>
+      <version>4.5.5-3.0</version>
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>


### PR DESCRIPTION
```
*  pom.xml: Use Apache HttpComponents Client 4.x API Plugin
   
   This removes httpclient-4.5.2.jar and httpcore-4.4.4.jar from the plugin
   package, cutting its size by almost a megabyte.
   
   Users can update the Apache HttpComponents plugin on their own without
   waiting on other plugins to update.
   
   Apache HttpComponents plugin, is likely to be installed already because
   it's used by git plugin.
```

Let's share this dependency like most modern plugins do. No need to bundle our own copy.