### PR TITLE
[TRIVIAL] pom.xml: Depend on hamcrest, not on hamcrest-library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
+      <artifactId>hamcrest</artifactId>
       <version>2.1</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
```
*  pom.xml: Depend on hamcrest, not on hamcrest-library
   
   hamcrest-library is a deprecated dependency, as indicated by
   hamcrest-library-2.1.pom.
```

For justification, see http://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-library/2.1/hamcrest-library-2.1.pom

Jackson changes have been moved to #125, they are more involved.