### PR TITLE
StashPullRequestComment: Rewrite Comparable interface implementation

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestComment.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestComment.java
@@ -1,11 +1,11 @@
 package stashpullrequestbuilder.stashpullrequestbuilder.stash;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Objects;
+import org.apache.commons.lang.StringUtils;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.codehaus.jackson.annotate.JsonProperty;
 
 /** Created by Nathan McCarthy */
-@SuppressFBWarnings("EQ_COMPARETO_USE_OBJECT_EQUALS")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StashPullRequestComment implements Comparable<StashPullRequestComment> {
 
@@ -31,13 +31,31 @@ public class StashPullRequestComment implements Comparable<StashPullRequestComme
   }
 
   @Override
-  public int compareTo(StashPullRequestComment target) {
-    if (this.getCommentId() > target.getCommentId()) {
-      return 1;
-    } else if (this.getCommentId().equals(target.getCommentId())) {
-      return 0;
-    } else {
-      return -1;
+  public int hashCode() {
+    return (commentId == null) ? Integer.MIN_VALUE : commentId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof StashPullRequestComment)) {
+      return false;
     }
+
+    StashPullRequestComment other = (StashPullRequestComment) o;
+
+    return Objects.equals(this.commentId, other.commentId)
+        && StringUtils.equals(this.text, other.text);
+  }
+
+  @Override
+  public int compareTo(StashPullRequestComment other) {
+    int ret =
+        Objects.compare(this.commentId, other.commentId, (Integer a, Integer b) -> a.compareTo(b));
+
+    if (ret != 0) {
+      return ret;
+    }
+
+    return Objects.compare(this.text, other.text, (String a, String b) -> a.compareTo(b));
   }
 }

--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestCommentTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestCommentTest.java
@@ -1,0 +1,244 @@
+package stashpullrequestbuilder.stashpullrequestbuilder.stash;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/** Unit tests for StashPullRequestComment */
+public class StashPullRequestCommentTest {
+
+  @Rule public ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void hashCode_behaves_as_expected() {
+    StashPullRequestComment comment = new StashPullRequestComment();
+    assertThat(comment.hashCode(), is(equalTo(Integer.MIN_VALUE)));
+
+    comment.setCommentId(Integer.MAX_VALUE);
+    assertThat(comment.hashCode(), is(equalTo(Integer.MAX_VALUE)));
+
+    comment.setCommentId(123);
+    assertThat(comment.hashCode(), is(equalTo(123)));
+
+    comment.setCommentId(-1000);
+    assertThat(comment.hashCode(), is(equalTo(-1000)));
+
+    comment.setText("42");
+    assertThat(comment.hashCode(), is(equalTo(-1000)));
+  }
+
+  @Test
+  public void comment_unequal_to_null() {
+    StashPullRequestComment comment = new StashPullRequestComment();
+
+    assertThat(comment.equals(null), is(equalTo(false)));
+  }
+
+  @Test
+  public void comment_compareTo_null_throws() {
+    StashPullRequestComment comment = new StashPullRequestComment();
+
+    expectedException.expect(NullPointerException.class);
+    comment.compareTo(null);
+  }
+
+  @Test
+  public void comments_with_same_id_and_same_text_are_equal() {
+    StashPullRequestComment comment1 = new StashPullRequestComment();
+    comment1.setCommentId(1);
+    comment1.setText("1");
+
+    StashPullRequestComment comment2 = new StashPullRequestComment();
+    comment2.setCommentId(1);
+    comment2.setText("1");
+
+    assertThat(comment1.equals(comment2), is(equalTo(true)));
+    assertThat(comment2.equals(comment1), is(equalTo(true)));
+    assertThat(comment1.compareTo(comment2), is(equalTo(0)));
+    assertThat(comment2.compareTo(comment1), is(equalTo(0)));
+  }
+
+  @Test
+  public void comments_with_different_id_and_same_text_are_unequal() {
+    StashPullRequestComment comment1 = new StashPullRequestComment();
+    comment1.setCommentId(1);
+    comment1.setText("1");
+
+    StashPullRequestComment comment2 = new StashPullRequestComment();
+    comment2.setCommentId(2);
+    comment2.setText("1");
+
+    assertThat(comment1.equals(comment2), is(equalTo(false)));
+    assertThat(comment2.equals(comment1), is(equalTo(false)));
+    assertThat(comment1.compareTo(comment2), is(lessThan(0)));
+    assertThat(comment2.compareTo(comment1), is(greaterThan(0)));
+  }
+
+  @Test
+  public void comments_with_same_id_and_different_text_are_unequal() {
+    StashPullRequestComment comment1 = new StashPullRequestComment();
+    comment1.setCommentId(1);
+    comment1.setText("1");
+
+    StashPullRequestComment comment2 = new StashPullRequestComment();
+    comment2.setCommentId(1);
+    comment2.setText("2");
+
+    assertThat(comment1.equals(comment2), is(equalTo(false)));
+    assertThat(comment2.equals(comment1), is(equalTo(false)));
+    assertThat(comment1.compareTo(comment2), is(lessThan(0)));
+    assertThat(comment2.compareTo(comment1), is(greaterThan(0)));
+  }
+
+  @Test
+  public void id_comparison_takes_precedence_over_string_comparison() {
+    StashPullRequestComment comment1 = new StashPullRequestComment();
+    comment1.setCommentId(1);
+    comment1.setText("1");
+
+    StashPullRequestComment comment2 = new StashPullRequestComment();
+    comment2.setCommentId(2);
+    comment2.setText("2");
+
+    assertThat(comment1.compareTo(comment2), is(lessThan(0)));
+    assertThat(comment2.compareTo(comment1), is(greaterThan(0)));
+
+    comment1.setCommentId(2);
+    comment2.setCommentId(1);
+
+    assertThat(comment1.compareTo(comment2), is(greaterThan(0)));
+    assertThat(comment2.compareTo(comment1), is(lessThan(0)));
+  }
+
+  @Test
+  public void comments_with_same_id_and_one_null_text_are_unequal() {
+    StashPullRequestComment comment1 = new StashPullRequestComment();
+    comment1.setCommentId(1);
+    comment1.setText("1");
+
+    StashPullRequestComment comment2 = new StashPullRequestComment();
+    comment2.setCommentId(1);
+
+    assertThat(comment1.equals(comment2), is(equalTo(false)));
+    assertThat(comment2.equals(comment1), is(equalTo(false)));
+  }
+
+  @Test
+  public void same_id_and_null_text_on_the_left_throws_in_compareTo() {
+    StashPullRequestComment comment1 = new StashPullRequestComment();
+    comment1.setCommentId(1);
+    comment1.setText("1");
+
+    StashPullRequestComment comment2 = new StashPullRequestComment();
+    comment2.setCommentId(1);
+
+    expectedException.expect(NullPointerException.class);
+    comment2.compareTo(comment1);
+  }
+
+  @Test
+  public void same_id_and_null_text_on_the_right_throws_in_compareTo() {
+    StashPullRequestComment comment1 = new StashPullRequestComment();
+    comment1.setCommentId(1);
+    comment1.setText("1");
+
+    StashPullRequestComment comment2 = new StashPullRequestComment();
+    comment2.setCommentId(1);
+
+    expectedException.expect(NullPointerException.class);
+    comment1.compareTo(comment2);
+  }
+
+  @Test
+  public void comments_with_same_id_and_null_text_on_both_sides_are_equal() {
+    StashPullRequestComment comment1 = new StashPullRequestComment();
+    comment1.setCommentId(1);
+
+    StashPullRequestComment comment2 = new StashPullRequestComment();
+    comment2.setCommentId(1);
+
+    assertThat(comment1.equals(comment2), is(equalTo(true)));
+    assertThat(comment2.equals(comment1), is(equalTo(true)));
+    assertThat(comment1.compareTo(comment2), is(equalTo(0)));
+    assertThat(comment2.compareTo(comment1), is(equalTo(0)));
+  }
+
+  @Test
+  public void comments_with_different_id_and_null_text_are_unequal() {
+    StashPullRequestComment comment1 = new StashPullRequestComment();
+    comment1.setCommentId(1);
+    comment1.setText("1");
+
+    StashPullRequestComment comment2 = new StashPullRequestComment();
+    comment2.setCommentId(2);
+
+    assertThat(comment1.equals(comment2), is(equalTo(false)));
+    assertThat(comment2.equals(comment1), is(equalTo(false)));
+    assertThat(comment1.compareTo(comment2), is(lessThan(0)));
+    assertThat(comment2.compareTo(comment1), is(greaterThan(0)));
+  }
+
+  @Test
+  public void comments_with_null_id_not_equal_to_nonnull_id() {
+    StashPullRequestComment comment1 = new StashPullRequestComment();
+    comment1.setCommentId(1);
+
+    StashPullRequestComment comment2 = new StashPullRequestComment();
+
+    assertThat(comment1.equals(comment2), is(equalTo(false)));
+    assertThat(comment2.equals(comment1), is(equalTo(false)));
+  }
+
+  @Test
+  public void null_id_on_the_left_throws() {
+    StashPullRequestComment comment1 = new StashPullRequestComment();
+
+    StashPullRequestComment comment2 = new StashPullRequestComment();
+    comment2.setCommentId(1);
+
+    expectedException.expect(NullPointerException.class);
+    comment1.compareTo(comment2);
+  }
+
+  @Test
+  public void null_id_on_the_right_throws() {
+    StashPullRequestComment comment1 = new StashPullRequestComment();
+    comment1.setCommentId(1);
+
+    StashPullRequestComment comment2 = new StashPullRequestComment();
+
+    expectedException.expect(NullPointerException.class);
+    assertThat(comment1.compareTo(comment2), is(equalTo(0)));
+  }
+
+  @Test
+  public void comments_with_both_null_id_and_same_text_equal() {
+    StashPullRequestComment comment1 = new StashPullRequestComment();
+    StashPullRequestComment comment2 = new StashPullRequestComment();
+
+    assertThat(comment1.equals(comment2), is(equalTo(true)));
+    assertThat(comment2.equals(comment1), is(equalTo(true)));
+    assertThat(comment1.compareTo(comment2), is(equalTo(0)));
+    assertThat(comment2.compareTo(comment1), is(equalTo(0)));
+  }
+
+  @Test
+  public void comments_with_both_null_id_and_different_text_unequal() {
+    StashPullRequestComment comment1 = new StashPullRequestComment();
+    comment1.setText("1");
+
+    StashPullRequestComment comment2 = new StashPullRequestComment();
+    comment2.setText("2");
+
+    assertThat(comment1.equals(comment2), is(equalTo(false)));
+    assertThat(comment2.equals(comment1), is(equalTo(false)));
+    assertThat(comment1.compareTo(comment2), is(lessThan(0)));
+    assertThat(comment2.compareTo(comment1), is(greaterThan(0)));
+  }
+}


### PR DESCRIPTION
```
*  StashPullRequestComment: Rewrite Comparable interface implementation
   
   Define hashCode() and equals() to ensure consistent behavior and fix
   FindBugs warnings.
   
   Treat null as Integer.MIN_VALUE in hashCode(), as that comment ID is not
   expected to be found in actual server responses.
   
   Compare text in compare() if comment ID is the same.
   
   Add extensive unit tests. Remove FindBugs suppressions.
```

FindBugs wanted `equals()` to be defined. Once I defined `equals()`, FindBugs asked for a `hashCode()` implementation.

`hashCode()` is rather simple. The only reason to override it is to have a version that only depends on the member values, not on the object addresses. That is needed to ensure that equal objects have equal hash codes.

For `equals()`, check ID and text. Use null-safe functions. `equals()` should never throw.

For compareTo(), compare ID first, then the text. Use `Objects.compare()`, which compares null to null as true, but throws when null is compared to non-null.

Maybe I overengineered it, but I don't want any checker to detect any issues with that code ever again.

For a simpler solution, see #123.