### PR TITLE
StashPullRequestComment: Remove compareTo() and Comparable interface

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -168,7 +168,10 @@ public class StashRepository {
         client.getPullRequestComments(owner, repositoryName, id);
 
     // Process newest comments last so they can override older comments
-    Collections.sort(comments);
+    Collections.sort(
+        comments,
+        (StashPullRequestComment a, StashPullRequestComment b) ->
+            a.getCommentId().compareTo(b.getCommentId()));
 
     Map<String, String> result = new TreeMap<String, String>();
 
@@ -567,8 +570,11 @@ public class StashRepository {
       return false;
     }
 
-    // Start with most recent comments
-    Collections.sort(comments, Collections.reverseOrder());
+    // Start with most recent comments, i.e. reverse sort by ID
+    Collections.sort(
+        comments,
+        (StashPullRequestComment a, StashPullRequestComment b) ->
+            b.getCommentId().compareTo(a.getCommentId()));
 
     for (StashPullRequestComment comment : comments) {
       String content = comment.getText();

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestComment.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestComment.java
@@ -1,13 +1,11 @@
 package stashpullrequestbuilder.stashpullrequestbuilder.stash;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.codehaus.jackson.annotate.JsonProperty;
 
 /** Created by Nathan McCarthy */
-@SuppressFBWarnings("EQ_COMPARETO_USE_OBJECT_EQUALS")
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class StashPullRequestComment implements Comparable<StashPullRequestComment> {
+public class StashPullRequestComment {
 
   private Integer commentId;
   private String text;
@@ -28,16 +26,5 @@ public class StashPullRequestComment implements Comparable<StashPullRequestComme
 
   public void setText(String text) {
     this.text = text;
-  }
-
-  @Override
-  public int compareTo(StashPullRequestComment target) {
-    if (this.getCommentId() > target.getCommentId()) {
-      return 1;
-    } else if (this.getCommentId().equals(target.getCommentId())) {
-      return 0;
-    } else {
-      return -1;
-    }
   }
 }


### PR DESCRIPTION
```
*  StashPullRequestComment: Remove compareTo() and Comparable interface
   
   Instead, define the comparator when comments need to be sorted.
   
   compareTo() required equals() and hashCode() to be defined to avoid
   FindBugs warnings. That's an overkill when the only use of compareTo() is
   to sort comments from the same pull request.
```

The initial fix was submitted as #122, but it was too complex, so I closed it.