### PR TITLE
[TRIVIAL] StashPullRequestActivity: Don't implement Comparable, it is not used

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestActivity.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestActivity.java
@@ -1,12 +1,10 @@
 package stashpullrequestbuilder.stashpullrequestbuilder.stash;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /** Created by Nathan on 20/03/2015. */
-@SuppressFBWarnings("EQ_COMPARETO_USE_OBJECT_EQUALS")
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class StashPullRequestActivity implements Comparable<StashPullRequestActivity> {
+public class StashPullRequestActivity {
   private StashPullRequestComment comment;
 
   public StashPullRequestComment getComment() {
@@ -15,22 +13,5 @@ public class StashPullRequestActivity implements Comparable<StashPullRequestActi
 
   public void setComment(StashPullRequestComment comment) {
     this.comment = comment;
-  }
-
-  @Override
-  public int compareTo(StashPullRequestActivity target) {
-    if (this.comment == null || target.getComment() == null) {
-      return -1;
-    }
-    int commentIdThis = this.comment.getCommentId();
-    int commentIdOther = target.getComment().getCommentId();
-
-    if (commentIdThis > commentIdOther) {
-      return 1;
-    } else if (commentIdThis == commentIdOther) {
-      return 0;
-    } else {
-      return -1;
-    }
   }
 }


### PR DESCRIPTION
```
*  StashPullRequestActivity: Don't implement Comparable, it is not used
   
   Remove FindBugs suppressions.
```

Extracted from #122. This part should be non-controversial. `compareTo()` in StashPullRequestActivity is dead code that doesn't give us anything except warnings.