### PR TITLE
Update to Jackson2 API, use Jenkins Jackson2 API plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This plugin was inspired by the GitHub & BitBucket pull request builder plugins.
 
 ## Prerequisites
 
-- Jenkins 2.60.1 or higher.
+- Jenkins 2.60.3 or higher.
 - [Git Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin)
 
 ## Environment variables

--- a/pom.xml
+++ b/pom.xml
@@ -72,9 +72,9 @@
       <version>1.10</version>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-jaxrs</artifactId>
-      <version>1.9.13</version>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jackson2-api</artifactId>
+      <version>2.9.9.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
     <revision>1.11</revision>
     <changelist>-SNAPSHOT</changelist>
     <java.level>8</java.level>
+    <jenkins.version>2.60.3</jenkins.version>
   </properties>
 
   <dependencies>

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
@@ -2,6 +2,8 @@ package stashpullrequestbuilder.stashpullrequestbuilder.stash;
 
 import static java.lang.String.format;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.io.InputStream;
@@ -49,8 +51,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.params.CoreConnectionPNames;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.node.ObjectNode;
 
 /** Created by Nathan McCarthy */
 @SuppressFBWarnings("EQ_DOESNT_OVERRIDE_EQUALS")

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestActivity.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestActivity.java
@@ -1,7 +1,7 @@
 package stashpullrequestbuilder.stashpullrequestbuilder.stash;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 
 /** Created by Nathan on 20/03/2015. */
 @SuppressFBWarnings("EQ_COMPARETO_USE_OBJECT_EQUALS")

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestActivityResponse.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestActivityResponse.java
@@ -1,9 +1,9 @@
 package stashpullrequestbuilder.stashpullrequestbuilder.stash;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
 
 /** Created by Nathan McCarthy */
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestComment.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestComment.java
@@ -1,8 +1,8 @@
 package stashpullrequestbuilder.stashpullrequestbuilder.stash;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
 
 /** Created by Nathan McCarthy */
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestMergeableResponse.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestMergeableResponse.java
@@ -1,7 +1,7 @@
 package stashpullrequestbuilder.stashpullrequestbuilder.stash;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.ArrayList;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 
 /**
  * If pull request is mergeable

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestMergeableVetoMessage.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestMergeableVetoMessage.java
@@ -1,6 +1,6 @@
 package stashpullrequestbuilder.stashpullrequestbuilder.stash;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 /**
  * If pull request is mergeable

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponse.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponse.java
@@ -1,8 +1,8 @@
 package stashpullrequestbuilder.stashpullrequestbuilder.stash;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
 
 /** Created by Nathan McCarthy */
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValue.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValue.java
@@ -1,7 +1,7 @@
 package stashpullrequestbuilder.stashpullrequestbuilder.stash;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /** Created by Nathan McCarthy */
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValueRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValueRepository.java
@@ -1,9 +1,9 @@
 package stashpullrequestbuilder.stashpullrequestbuilder.stash;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang.StringUtils;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
 
 /** Created by Nathan McCarthy */
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValueRepositoryBranch.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValueRepositoryBranch.java
@@ -1,6 +1,6 @@
 package stashpullrequestbuilder.stashpullrequestbuilder.stash;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StashPullRequestResponseValueRepositoryBranch {

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValueRepositoryCommit.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValueRepositoryCommit.java
@@ -1,6 +1,6 @@
 package stashpullrequestbuilder.stashpullrequestbuilder.stash;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StashPullRequestResponseValueRepositoryCommit {

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValueRepositoryProject.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValueRepositoryProject.java
@@ -1,6 +1,6 @@
 package stashpullrequestbuilder.stashpullrequestbuilder.stash;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StashPullRequestResponseValueRepositoryProject {

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValueRepositoryRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValueRepositoryRepository.java
@@ -1,7 +1,7 @@
 package stashpullrequestbuilder.stashpullrequestbuilder.stash;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StashPullRequestResponseValueRepositoryRepository {

--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClientTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClientTest.java
@@ -25,13 +25,13 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import com.github.tomakehurst.wiremock.client.BasicCredentials;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
-import org.codehaus.jackson.JsonParseException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;


### PR DESCRIPTION
```
*  Update to Jackson2 API, use Jenkins Jackson2 API plugin
   
   Require Jenkins 2.60.3, all recent versions of Jackson2 API plugin
   require it.
```

This change makes this plugin smaller and gives Jenkins administrators control over the version of Jackson. Version 1.9.13 is 6 years old and completely unsupported. There have been many security issues with Jackson since then.

With the dependency on Jackson2 API plugin all it takes is to update that plugin.