### PR TITLE
Add a "polling log" page as a link on the project page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,12 @@
       <version>4.5.5-3.0</version>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4jVersion}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock-jre8-standalone</artifactId>
       <version>2.23.2</version>

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPollingAction.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPollingAction.java
@@ -1,0 +1,76 @@
+package stashpullrequestbuilder.stashpullrequestbuilder;
+
+import hudson.Functions;
+import hudson.model.Action;
+import hudson.model.Job;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.apache.commons.jelly.XMLOutput;
+import org.slf4j.helpers.FormattingTuple;
+import org.slf4j.helpers.MessageFormatter;
+import org.xml.sax.SAXException;
+
+/**
+ * Add "Polling Log" item to the project menu.
+ *
+ * <p>The class provides a method to log messages and exceptions that supports slf4j
+ * MessageFormatter patterns.
+ */
+public class StashPollingAction implements Action {
+
+  private final Job<?, ?> owner;
+  private StringWriter stringWriter;
+  private PrintWriter printWriter;
+
+  public StashPollingAction(final Job<?, ?> job) {
+    this.owner = job;
+    stringWriter = new StringWriter();
+    printWriter = new PrintWriter(stringWriter);
+  }
+
+  @Override
+  public String getIconFileName() {
+    return "clipboard.png";
+  }
+
+  @Override
+  public String getDisplayName() {
+    return "Polling Log";
+  }
+
+  @Override
+  public String getUrlName() {
+    return "stash-polling";
+  }
+
+  public Job<?, ?> getOwner() {
+    return owner;
+  }
+
+  public void log(String pattern, Object... arguments) {
+    FormattingTuple tuple = MessageFormatter.arrayFormat(pattern, arguments);
+
+    String logEntry = tuple.getMessage();
+    printWriter.println(logEntry);
+
+    Throwable throwable = tuple.getThrowable();
+    if (throwable != null) {
+      Functions.printStackTrace(throwable, printWriter);
+    }
+  }
+
+  public void resetLog() {
+    printWriter.flush();
+    stringWriter.getBuffer().setLength(0);
+  }
+
+  @Override
+  public String toString() {
+    printWriter.flush();
+    return stringWriter.toString();
+  }
+
+  public void writeLogTo(XMLOutput out) throws SAXException {
+    out.write(this.toString());
+  }
+}

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPollingActionFactory.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPollingActionFactory.java
@@ -1,0 +1,46 @@
+package stashpullrequestbuilder.stashpullrequestbuilder;
+
+import hudson.Extension;
+import hudson.model.Action;
+import hudson.model.Job;
+import hudson.model.TopLevelItem;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import javax.annotation.Nonnull;
+import jenkins.model.ParameterizedJobMixIn;
+import jenkins.model.TransientActionFactory;
+
+/** Inject StashPollingAction into its owning item. */
+@Extension
+public class StashPollingActionFactory extends TransientActionFactory<TopLevelItem> {
+
+  @Override
+  public Class<TopLevelItem> type() {
+    return TopLevelItem.class;
+  }
+
+  @Nonnull
+  @Override
+  public Collection<? extends Action> createFor(@Nonnull TopLevelItem item) {
+    List<Action> actions = new ArrayList<>();
+
+    if (!(item instanceof Job)) {
+      return actions;
+    }
+
+    Job<?, ?> job = (Job<?, ?>) item;
+
+    StashBuildTrigger trigger = ParameterizedJobMixIn.getTrigger(job, StashBuildTrigger.class);
+    if (trigger == null) {
+      return actions;
+    }
+
+    StashPollingAction stashPollingAction = trigger.getStashPollingAction();
+    if (stashPollingAction != null) {
+      actions.add(stashPollingAction);
+    }
+
+    return actions;
+  }
+}

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -2,6 +2,7 @@ package stashpullrequestbuilder.stashpullrequestbuilder;
 
 import static java.lang.String.format;
 
+import hudson.Util;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
 import hudson.model.Executor;
@@ -15,6 +16,7 @@ import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.StringParameterValue;
 import java.lang.invoke.MethodHandles;
+import java.text.SimpleDateFormat;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -67,6 +69,8 @@ public class StashRepository {
   private StashBuildTrigger trigger;
   private StashApiClient client;
 
+  private long pollStartTime;
+
   public StashRepository(@Nonnull Job<?, ?> job, @Nonnull StashBuildTrigger trigger) {
     this(job, trigger, makeStashApiClient(trigger));
   }
@@ -89,8 +93,16 @@ public class StashRepository {
         trigger.getIgnoreSsl());
   }
 
+  private static String logTimestamp() {
+    return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z").format(new java.util.Date());
+  }
+
   public Collection<StashPullRequestResponseValue> getTargetPullRequests() {
-    logger.info(format("Fetch PullRequests (%s).", job.getName()));
+    pollStartTime = System.currentTimeMillis();
+    StashPollingAction pollLog = trigger.getStashPollingAction();
+    pollLog.resetLog();
+    pollLog.log("{}: poll started", logTimestamp());
+
     List<StashPullRequestResponseValue> targetPullRequests =
         new ArrayList<StashPullRequestResponseValue>();
 
@@ -101,15 +113,21 @@ public class StashRepository {
     try {
       pullRequests = client.getPullRequests();
     } catch (StashApiException e) {
+      pollLog.log("Cannot fetch pull request list", e);
       logger.log(Level.INFO, format("%s: cannot fetch pull request list", job.getName()), e);
       return targetPullRequests;
     }
+
+    pollLog.log("Number of open pull requests: {}", pullRequests.size());
 
     for (StashPullRequestResponseValue pullRequest : pullRequests) {
       if (isBuildTarget(pullRequest)) {
         targetPullRequests.add(pullRequest);
       }
     }
+
+    pollLog.log("Number of pull requests to be built: {}", targetPullRequests.size());
+
     return targetPullRequests;
   }
 
@@ -277,6 +295,8 @@ public class StashRepository {
   }
 
   public void addFutureBuildTasks(Collection<StashPullRequestResponseValue> pullRequests) {
+    StashPollingAction pollLog = trigger.getStashPollingAction();
+
     for (StashPullRequestResponseValue pullRequest : pullRequests) {
       Map<String, String> additionalParameters;
 
@@ -286,6 +306,8 @@ public class StashRepository {
       try {
         additionalParameters = getAdditionalParameters(pullRequest);
       } catch (StashApiException e) {
+        pollLog.log(
+            "Cannot read additional parameters for PR #{}, skipping", pullRequest.getId(), e);
         logger.log(
             Level.INFO,
             format(
@@ -301,6 +323,8 @@ public class StashRepository {
         try {
           deletePreviousBuildFinishedComments(pullRequest);
         } catch (StashApiException e) {
+          pollLog.log(
+              "Cannot delete old \"BuildFinished\" comments for PR #{}", pullRequest.getId(), e);
           logger.log(
               Level.INFO,
               format(
@@ -320,6 +344,10 @@ public class StashRepository {
       try {
         commentId = postBuildStartCommentTo(pullRequest);
       } catch (StashApiException e) {
+        pollLog.log(
+            "Cannot post \"BuildStarted\" comment for PR #{}, not building",
+            pullRequest.getId(),
+            e);
         logger.log(
             Level.INFO,
             format(
@@ -345,8 +373,19 @@ public class StashRepository {
               commentId,
               pullRequest.getVersion(),
               additionalParameters);
-      startJob(cause);
+
+      Queue.Item item = startJob(cause);
+      if (item != null) {
+        pollLog.log("Queued job for PR #{}", pullRequest.getId());
+      } else {
+        pollLog.log("Failed to queue job for PR #{}", pullRequest.getId());
+      }
     }
+
+    pollLog.log(
+        "{}: poll completed in {}",
+        logTimestamp(),
+        Util.getTimeSpanString(System.currentTimeMillis() - pollStartTime));
   }
 
   /**
@@ -665,7 +704,6 @@ public class StashRepository {
   }
 
   public void pollRepository() {
-    logger.info(format("Build Start (%s).", job.getName()));
     Collection<StashPullRequestResponseValue> targetPullRequests = getTargetPullRequests();
     addFutureBuildTasks(targetPullRequests);
   }

--- a/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashPollingAction/index.jelly
+++ b/src/main/resources/stashpullrequestbuilder/stashpullrequestbuilder/StashPollingAction/index.jelly
@@ -1,0 +1,13 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+  <l:layout>
+    <st:include it="${it.owner}" page="sidepanel.jelly"/>
+    <l:main-panel>
+      <h1>${%Bitbucket Server Polling Log}</h1>
+      <pre>
+        <st:getOutput var="output"/>
+        <j:whitespace>${it.writeLogTo(output)}</j:whitespace>
+      </pre>
+    </l:main-panel>
+  </l:layout>
+</j:jelly>

--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPollingActionFactoryTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPollingActionFactoryTest.java
@@ -1,0 +1,85 @@
+package stashpullrequestbuilder.stashpullrequestbuilder;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import hudson.model.Action;
+import hudson.model.FreeStyleProject;
+import hudson.model.TopLevelItem;
+import hudson.triggers.Trigger;
+import hudson.triggers.TriggerDescriptor;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StashPollingActionFactoryTest {
+
+  @Rule public JenkinsRule jenkinsRule = new JenkinsRule();
+  @Rule public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+
+  private StashPollingActionFactory factory = new StashPollingActionFactory();
+
+  @Test
+  public void type_returns_TopLevelItem() {
+    assertThat(factory.type(), is(equalTo(TopLevelItem.class)));
+  }
+
+  @Test
+  public void createFor_returns_empty_list_for_TopLevelItem() {
+    TopLevelItem item = mock(TopLevelItem.class);
+
+    assertThat(factory.createFor(item), is(empty()));
+  }
+
+  @Test
+  public void createFor_returns_empty_list_for_FreeStyleProject() {
+    FreeStyleProject project = mock(FreeStyleProject.class);
+
+    assertThat(factory.createFor(project), is(empty()));
+  }
+
+  @Test
+  public void createFor_returns_empty_list_if_no_StashPollingAction() throws Exception {
+    StashBuildTrigger trigger = mock(StashBuildTrigger.class);
+    FreeStyleProject project = spy(jenkinsRule.createFreeStyleProject());
+
+    Map<TriggerDescriptor, Trigger<?>> triggerMap = new HashMap<>();
+    triggerMap.put(StashBuildTrigger.descriptor, trigger);
+
+    when(project.getTriggers()).thenReturn(triggerMap);
+    when(trigger.getStashPollingAction()).thenReturn(null);
+
+    assertThat(factory.createFor(project), is(empty()));
+  }
+
+  @Test
+  public void createFor_returns_action_for_project_with_StashBuildTrigger() throws Exception {
+    StashBuildTrigger trigger = mock(StashBuildTrigger.class);
+    FreeStyleProject project = spy(jenkinsRule.createFreeStyleProject());
+    StashPollingAction stashPollingAction = new StashPollingAction(project);
+
+    Map<TriggerDescriptor, Trigger<?>> triggerMap = new HashMap<>();
+    triggerMap.put(StashBuildTrigger.descriptor, trigger);
+
+    when(project.getTriggers()).thenReturn(triggerMap);
+    when(trigger.getStashPollingAction()).thenReturn(stashPollingAction);
+
+    Collection<? extends Action> actions = factory.createFor(project);
+    assertThat(actions, contains(stashPollingAction));
+  }
+}

--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPollingActionTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashPollingActionTest.java
@@ -1,0 +1,117 @@
+package stashpullrequestbuilder.stashpullrequestbuilder;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import hudson.model.FreeStyleProject;
+import java.io.IOException;
+import org.apache.commons.jelly.XMLOutput;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StashPollingActionTest {
+
+  @Rule public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+
+  @Mock FreeStyleProject project;
+  private StashPollingAction stashPollingAction;
+
+  @Before
+  public void before() {
+    stashPollingAction = new StashPollingAction(project);
+  }
+
+  @Test
+  public void getIconFileName_returns_expected_value() {
+    assertThat(stashPollingAction.getIconFileName(), is(equalTo("clipboard.png")));
+  }
+
+  @Test
+  public void getDisplayName_returns_expected_value() {
+    assertThat(stashPollingAction.getDisplayName(), is(equalTo("Polling Log")));
+  }
+
+  @Test
+  public void getUrlName_returns_expected_value() {
+    assertThat(stashPollingAction.getUrlName(), is(equalTo("stash-polling")));
+  }
+
+  @Test
+  public void getOwner_returns_expected_value() {
+    assertThat(stashPollingAction.getOwner(), is(equalTo(project)));
+  }
+
+  @Test
+  public void log_records_string_with_newline() {
+    stashPollingAction.log("Some message");
+    assertThat(stashPollingAction.toString(), matchesPattern("^Some message(\\r?\\n|\\r)$"));
+  }
+
+  @Test
+  public void log_formats_arguments() {
+    stashPollingAction.log("{}: found {} items", "Finder", 5);
+    assertThat(
+        stashPollingAction.toString(), matchesPattern("^Finder: found 5 items(\\r?\\n|\\r)$"));
+  }
+
+  @Test
+  public void log_records_string_and_exception() {
+    IOException e = new IOException("Read Error");
+    stashPollingAction.log("{}, {} and {}", "one", "two", "three", e);
+
+    String[] logLines = stashPollingAction.toString().split("\\r?\\n|\\r");
+    assertThat(logLines.length, is(greaterThanOrEqualTo(3)));
+    assertThat(logLines[0], is(equalTo("one, two and three")));
+    assertThat(logLines[1], is(equalTo("java.io.IOException: Read Error")));
+    for (int i = 2; i < logLines.length; i++) {
+      assertThat(logLines[i], matchesPattern("^\\tat [A-Za-z0-9_$.]+\\(.*\\)$"));
+    }
+  }
+
+  @Test
+  public void log_appends_messages() {
+    stashPollingAction.log("First message");
+    stashPollingAction.log("Second message");
+    String[] logLines = stashPollingAction.toString().split("\\r?\\n|\\r");
+    assertThat(logLines.length, is(equalTo(2)));
+    assertThat(logLines[0], is(equalTo("First message")));
+    assertThat(logLines[1], is(equalTo("Second message")));
+  }
+
+  @Test
+  public void reset_clears_messages() {
+    stashPollingAction.log("First message");
+    stashPollingAction.resetLog();
+    stashPollingAction.log("Second message");
+    String[] logLines = stashPollingAction.toString().split("\\r?\\n|\\r");
+    assertThat(logLines.length, is(equalTo(1)));
+    assertThat(logLines[0], is(equalTo("Second message")));
+  }
+
+  @Test
+  public void writeLogTo_writes_log_without_escaping() throws Exception {
+    XMLOutput xmlOut = mock(XMLOutput.class);
+    ArgumentCaptor<String> stringCaptor = ArgumentCaptor.forClass(String.class);
+
+    stashPollingAction.log("\"Fish\" & <i>chips</i>");
+    stashPollingAction.writeLogTo(xmlOut);
+    verify(xmlOut, times(1)).write(stringCaptor.capture());
+
+    assertThat(stringCaptor.getValue(), matchesPattern("^\"Fish\" & <i>chips</i>(\\r?\\n|\\r)$"));
+  }
+}

--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepositoryTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepositoryTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -85,6 +86,7 @@ public class StashRepositoryTest {
   public void before() throws Exception {
     project = spy(jenkinsRule.createFreeStyleProject());
     stashRepository = new StashRepository(project, trigger, stashApiClient);
+    lenient().when(trigger.getStashPollingAction()).thenReturn(new StashPollingAction(project));
 
     branch = new StashPullRequestResponseValueRepositoryBranch();
     branch.setName("feature/add-bloat");


### PR DESCRIPTION
```
*  Add a "Polling Log" page as a link on the project page
   
   Add StashPollingAction class, which is an Action and a logger. Use slf4j
   MessageFormatter for the log messages.
   
   StashPollingActionFactory is used to inject StashPollingAction into the
   project using the Extension mechanism.
   
   Change StashBuildTrigger and StashRepository to write information about
   polling to the polling log. Some messages are now logged both to the
   polling log and to the global Jenkins log.
```

Without this change, the plugin writes to the Jenkins log for every poll. That makes it a major source of log messages that provide very little value. 

In most cases, the Jenkins administrator doesn't care when the polls happened in the past. To check if polling is working, it's sufficient to check the time of the last poll.

Jenkins administrators may also be interested why a particular pull request is not triggering a build. The latest reason not to build the PR should be sufficient. It's not like the reason would change over time, and even if it changes, the last reason is most relevant.

Other triggers, such as Git Plugin, provide a polling log link on the project page. This PR makes Stash Pull Request Builder do the same.

This PR takes care of the infrastructure. The polling log contains the time when the last poll was run, its duration and the number of PRs to be built. More logging can be moved to the poll log in the future.