### PR TITLE
Use lowercase "name" field in StashPullRequestResponseValueRepositoryBranch

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValueRepositoryBranch.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValueRepositoryBranch.java
@@ -4,13 +4,13 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StashPullRequestResponseValueRepositoryBranch {
-  private String Name;
+  private String name;
 
   public String getName() {
-    return Name;
+    return name;
   }
 
   public void setName(String name) {
-    Name = name;
+    this.name = name;
   }
 }

--- a/src/test/resources/__files/PullRequestListSingle.json
+++ b/src/test/resources/__files/PullRequestListSingle.json
@@ -1,0 +1,43 @@
+{
+  "isLastPage" : true,
+  "values" : [
+    {
+      "closed" : false,
+      "createdDate" : "2017/11/20 8:20:59",
+      "description" : "Expand code to make it slower",
+      "fromRef" : {
+        "branch" : {
+          "name" : "MadeFromId"
+        },
+        "id" : "refs/heads/abc",
+        "latestChangeset" : "13",
+        "latestCommit" : "DCBA",
+        "repository" : {
+          "project" : {
+            "key" : "MyClone"
+          },
+          "slug" : "~Me"
+        }
+      },
+      "id" : "1001",
+      "locked" : false,
+      "state" : "OPEN",
+      "title" : "Add some bloat",
+      "toRef" : {
+        "branch" : {
+          "Name" : "Incorrect",
+          "name" : "master"
+        },
+        "latestCommit" : "ABCD",
+        "repository" : {
+          "project" : {
+            "key" : "PROJ"
+          },
+          "slug" : "BigRepo"
+        }
+      },
+      "updatedDate" : "2018/02/03 15:33:14",
+      "version" : "3.11"
+    }
+  ]
+}


### PR DESCRIPTION
Calling a private field `Name` is one of the issues found by FindBugs when stricter settings are enabled. Let's fix those issues and enable stricter checks.

Renaming `Name` to `name` is trivial. But since JSON mapper is involved, I added a unit test to make sure the behavior doesn't change.

Both before and after the change, the branch name is read from the `"name"` key. The `"Name"` key is ignored.