### PR TITLE
pom.xml: Fix Jenkins not detecting bad pom.xml formatting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,11 +145,6 @@
             <excludePackageNames>stashpullrequestbuilder.stashpullrequestbuilder.repackage.*</excludePackageNames>
           </configuration>
         </plugin>
-        <plugin>
-          <groupId>com.coveo</groupId>
-          <artifactId>fmt-maven-plugin</artifactId>
-          <version>2.8</version>
-        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -170,9 +165,20 @@
           <execution>
             <id>sortpom</id>
             <goals>
-              <goal>verify</goal>
+              <goal>sort</goal>
             </goals>
-            <phase>validate</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.coveo</groupId>
+        <artifactId>fmt-maven-plugin</artifactId>
+        <version>2.8</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>format</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>
@@ -181,51 +187,7 @@
 
   <profiles>
     <profile>
-      <id>verify-pom-sorting</id>
-      <activation>
-        <property>
-          <name>env.JENKINS_SERVER_COOKIE</name>
-        </property>
-      </activation>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>com.github.ekryd.sortpom</groupId>
-              <artifactId>sortpom-maven-plugin</artifactId>
-              <configuration>
-                <verifyFail>Stop</verifyFail>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
-    </profile>
-    <profile>
-      <id>format-java</id>
-      <activation>
-        <property>
-          <name>!env.JENKINS_SERVER_COOKIE</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.coveo</groupId>
-            <artifactId>fmt-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>format</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>verify-java-formatting</id>
+      <id>ensure-no-formatting-changes</id>
       <activation>
         <property>
           <name>env.JENKINS_SERVER_COOKIE</name>
@@ -234,13 +196,15 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>com.coveo</groupId>
-            <artifactId>fmt-maven-plugin</artifactId>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-scm-plugin</artifactId>
+            <version>1.11.2</version>
             <executions>
               <execution>
                 <goals>
-                  <goal>check</goal>
+                  <goal>check-local-modification</goal>
                 </goals>
+                <phase>verify</phase>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
```
*  pom.xml: Fix Jenkins not detecting bad pom.xml formatting
   
   The sortpom:verify goal is set to sort pom.xml if it finds any issues.
   That goal would not fail in case of bad pom.xml formatting, and Jenkins
   would not know that pom.xml needs sorting.
   
   But even when "verifyFail" is set to "Stop", sortpom:verify doesn't fail
   on minor formatting issues that sortpom:sort would fix. It would be
   better to make Jenkins detect all formatting issues in pom.xml.
   
   Instead of running sortpom:verify, run sortpom:sort unconditionally, i.e.
   on Jenkins and on other systems. There is no good reason to skip any
   goals on Jenkins if they are run elsewhere.
   
   The only additional behavior for Jenkins is checking for changes in the
   working directory. Jenkins would fail the build if the code is different
   from the checked out commit. Check for modifications at the "verify"
   phase, so that all other issues (e.g. findbugs and unit tests failures)
   would be detected first.
   
   To keep the build logic consistent, use the same approach for Java code
   formatting. Format Java code unconditionally. Jenkins would fail the test
   if any changes are detected.
```