### PR TITLE
Update to parent POM 3.48, add SpotBugs settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.10</version>
+    <version>3.48</version>
   </parent>
 
   <artifactId>stash-pullrequest-builder</artifactId>
@@ -58,6 +58,8 @@
     <changelist>-SNAPSHOT</changelist>
     <java.level>8</java.level>
     <jenkins.version>2.60.3</jenkins.version>
+    <spotbugs.effort>Max</spotbugs.effort>
+    <spotbugs.threshold>Medium</spotbugs.threshold>
   </properties>
 
   <dependencies>
@@ -97,7 +99,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.27.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
The update makes "mvn verify" invoke SpotBugs instead of FindBugs.

Don't set Mockito version, the parent is using a newer version.