### PR TITLE
StashApiClient: Run HTTP requests in the main thread

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
@@ -245,15 +245,13 @@ public class StashApiClient {
     request.addHeader("Connection", "close");
 
     String response = null;
-    FutureTask<String> httpTask = null;
-    Thread thread;
     try {
       request.addHeader(new BasicScheme().authenticate(credentials, request, null));
 
       // Run the HTTP request in a future task so we have the opportunity
       // to cancel it if it gets hung up; which is possible if stuck at
       // socket native layer.  see issue JENKINS-30558
-      httpTask =
+      FutureTask<String> httpTask =
           new FutureTask<String>(
               new Callable<String>() {
 
@@ -284,7 +282,7 @@ public class StashApiClient {
                   return this;
                 }
               }.init(client, request));
-      thread = new Thread(httpTask);
+      Thread thread = new Thread(httpTask);
       thread.start();
       response = httpTask.get(HTTP_REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
@@ -310,16 +308,13 @@ public class StashApiClient {
     request.setHeader("Connection", "close");
 
     int response = -1;
-    FutureTask<Integer> httpTask = null;
-    Thread thread;
-
     try {
       request.addHeader(new BasicScheme().authenticate(credentials, request, null));
 
       // Run the HTTP request in a future task so we have the opportunity
       // to cancel it if it gets hung up; which is possible if stuck at
       // socket native layer.  see issue JENKINS-30558
-      httpTask =
+      FutureTask<Integer> httpTask =
           new FutureTask<Integer>(
               new Callable<Integer>() {
 
@@ -339,7 +334,7 @@ public class StashApiClient {
                   return this;
                 }
               }.init(client, request));
-      thread = new Thread(httpTask);
+      Thread thread = new Thread(httpTask);
       thread.start();
       response = httpTask.get(HTTP_REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
@@ -381,16 +376,13 @@ public class StashApiClient {
     }
 
     String response = "";
-    FutureTask<String> httpTask = null;
-    Thread thread;
-
     try {
       request.addHeader(new BasicScheme().authenticate(credentials, request, null));
 
       // Run the HTTP request in a future task so we have the opportunity
       // to cancel it if it gets hung up; which is possible if stuck at
       // socket native layer.  see issue JENKINS-30558
-      httpTask =
+      FutureTask<String> httpTask =
           new FutureTask<String>(
               new Callable<String>() {
 
@@ -421,7 +413,7 @@ public class StashApiClient {
                   return this;
                 }
               }.init(client, request));
-      thread = new Thread(httpTask);
+      Thread thread = new Thread(httpTask);
       thread.start();
       response = httpTask.get(HTTP_REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
@@ -13,11 +13,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.FutureTask;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
@@ -46,10 +41,6 @@ import org.apache.http.util.EntityUtils;
 
 /** Created by Nathan McCarthy */
 public class StashApiClient {
-
-  // Request timeout: maximum time between sending an HTTP request and receiving
-  // a response to it from the server.
-  private static final int HTTP_REQUEST_TIMEOUT_SECONDS = 60;
 
   // Connection timeout: maximum time for connecting to the HTTP server.
   private static final int HTTP_CONNECTION_TIMEOUT_SECONDS = 15;
@@ -247,49 +238,19 @@ public class StashApiClient {
     String response = null;
     try {
       request.addHeader(new BasicScheme().authenticate(credentials, request, null));
+      HttpResponse httpResponse = client.execute(request);
+      int responseCode = httpResponse.getStatusLine().getStatusCode();
+      if (!validResponseCode(responseCode)) {
+        logger.log(Level.SEVERE, "Failing to get response from Stash PR GET" + request.getURI());
+        throw new StashApiException(
+            "Didn't get a 200 response from Stash PR GET! Response; '"
+                + responseCode
+                + "' with message; "
+                + httpResponse.getStatusLine().getReasonPhrase());
+      }
 
-      // Run the HTTP request in a future task so we have the opportunity
-      // to cancel it if it gets hung up; which is possible if stuck at
-      // socket native layer.  see issue JENKINS-30558
-      FutureTask<String> httpTask =
-          new FutureTask<String>(
-              new Callable<String>() {
-
-                private CloseableHttpClient client;
-                private HttpGet request;
-
-                @Override
-                public String call() throws StashApiException, IOException {
-                  HttpResponse httpResponse = client.execute(request);
-                  int responseCode = httpResponse.getStatusLine().getStatusCode();
-                  if (!validResponseCode(responseCode)) {
-                    logger.log(
-                        Level.SEVERE,
-                        "Failing to get response from Stash PR GET" + request.getURI());
-                    throw new StashApiException(
-                        "Didn't get a 200 response from Stash PR GET! Response; '"
-                            + responseCode
-                            + "' with message; "
-                            + httpResponse.getStatusLine().getReasonPhrase());
-                  }
-
-                  return entityAsString(httpResponse);
-                }
-
-                public Callable<String> init(CloseableHttpClient client, HttpGet request) {
-                  this.client = client;
-                  this.request = request;
-                  return this;
-                }
-              }.init(client, request));
-      Thread thread = new Thread(httpTask);
-      thread.start();
-      response = httpTask.get(HTTP_REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-
-    } catch (TimeoutException e) {
-      request.abort();
-      throw new StashApiException("Timeout in GET request", e);
-    } catch (AuthenticationException | ExecutionException | InterruptedException e) {
+      response = entityAsString(httpResponse);
+    } catch (AuthenticationException | IOException e) {
       throw new StashApiException("Exception in GET request", e);
     } finally {
       request.releaseConnection();
@@ -310,38 +271,8 @@ public class StashApiClient {
     int response = -1;
     try {
       request.addHeader(new BasicScheme().authenticate(credentials, request, null));
-
-      // Run the HTTP request in a future task so we have the opportunity
-      // to cancel it if it gets hung up; which is possible if stuck at
-      // socket native layer.  see issue JENKINS-30558
-      FutureTask<Integer> httpTask =
-          new FutureTask<Integer>(
-              new Callable<Integer>() {
-
-                private CloseableHttpClient client;
-                private HttpDelete request;
-
-                @Override
-                public Integer call() throws StashApiException, IOException {
-                  int response = -1;
-                  response = client.execute(request).getStatusLine().getStatusCode();
-                  return response;
-                }
-
-                public Callable<Integer> init(CloseableHttpClient client, HttpDelete request) {
-                  this.client = client;
-                  this.request = request;
-                  return this;
-                }
-              }.init(client, request));
-      Thread thread = new Thread(httpTask);
-      thread.start();
-      response = httpTask.get(HTTP_REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-
-    } catch (TimeoutException e) {
-      request.abort();
-      throw new StashApiException("Timeout in DELETE request", e);
-    } catch (AuthenticationException | ExecutionException | InterruptedException e) {
+      response = client.execute(request).getStatusLine().getStatusCode();
+    } catch (AuthenticationException | IOException e) {
       throw new StashApiException("Exception in DELETE request", e);
     } finally {
       request.releaseConnection();
@@ -378,49 +309,19 @@ public class StashApiClient {
     String response = "";
     try {
       request.addHeader(new BasicScheme().authenticate(credentials, request, null));
+      HttpResponse httpResponse = client.execute(request);
+      int responseCode = httpResponse.getStatusLine().getStatusCode();
+      if (!validResponseCode(responseCode)) {
+        logger.log(Level.SEVERE, "Failing to get response from Stash PR POST" + request.getURI());
+        throw new StashApiException(
+            "Didn't get a 200 response from Stash PR POST! Response; '"
+                + responseCode
+                + "' with message; "
+                + httpResponse.getStatusLine().getReasonPhrase());
+      }
 
-      // Run the HTTP request in a future task so we have the opportunity
-      // to cancel it if it gets hung up; which is possible if stuck at
-      // socket native layer.  see issue JENKINS-30558
-      FutureTask<String> httpTask =
-          new FutureTask<String>(
-              new Callable<String>() {
-
-                private CloseableHttpClient client;
-                private HttpPost request;
-
-                @Override
-                public String call() throws StashApiException, IOException {
-                  HttpResponse httpResponse = client.execute(request);
-                  int responseCode = httpResponse.getStatusLine().getStatusCode();
-                  if (!validResponseCode(responseCode)) {
-                    logger.log(
-                        Level.SEVERE,
-                        "Failing to get response from Stash PR POST" + request.getURI());
-                    throw new StashApiException(
-                        "Didn't get a 200 response from Stash PR POST! Response; '"
-                            + responseCode
-                            + "' with message; "
-                            + httpResponse.getStatusLine().getReasonPhrase());
-                  }
-
-                  return entityAsString(httpResponse);
-                }
-
-                public Callable<String> init(CloseableHttpClient client, HttpPost request) {
-                  this.client = client;
-                  this.request = request;
-                  return this;
-                }
-              }.init(client, request));
-      Thread thread = new Thread(httpTask);
-      thread.start();
-      response = httpTask.get(HTTP_REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-
-    } catch (TimeoutException e) {
-      request.abort();
-      throw new StashApiException("Timeout in POST request", e);
-    } catch (AuthenticationException | ExecutionException | InterruptedException e) {
+      response = entityAsString(httpResponse);
+    } catch (AuthenticationException | IOException e) {
       throw new StashApiException("Exception in POST request", e);
     } finally {
       request.releaseConnection();

--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClientTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClientTest.java
@@ -32,8 +32,9 @@ import com.github.tomakehurst.wiremock.client.BasicCredentials;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.net.SocketException;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
+import org.apache.http.client.ClientProtocolException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -194,8 +195,11 @@ public class StashApiClientTest {
     assertThat(
         assertThrows(StashApiException.class, () -> client.getPullRequests()),
         allOf(
-            hasProperty("cause", is(instanceOf(ExecutionException.class))),
-            hasProperty("message", containsString("Exception in GET request"))));
+            hasProperty("cause", is(nullValue())),
+            hasProperty(
+                "message",
+                containsString(
+                    "Didn't get a 200 response from Stash PR GET! Response; '404' with message; Not Found"))));
   }
 
   @Test
@@ -205,7 +209,7 @@ public class StashApiClientTest {
     assertThat(
         assertThrows(StashApiException.class, () -> client.getPullRequests()),
         allOf(
-            hasProperty("cause", is(instanceOf(ExecutionException.class))),
+            hasProperty("cause", is(instanceOf(ClientProtocolException.class))),
             hasProperty("message", containsString("Exception in GET request"))));
   }
 
@@ -216,7 +220,7 @@ public class StashApiClientTest {
     assertThat(
         assertThrows(StashApiException.class, () -> client.getPullRequests()),
         allOf(
-            hasProperty("cause", is(instanceOf(ExecutionException.class))),
+            hasProperty("cause", is(instanceOf(SocketException.class))),
             hasProperty("message", containsString("Exception in GET request"))));
   }
 
@@ -258,8 +262,11 @@ public class StashApiClientTest {
             StashApiException.class,
             () -> client.getPullRequestComments(projectName, repositoryName, pullRequestId)),
         allOf(
-            hasProperty("cause", is(instanceOf(ExecutionException.class))),
-            hasProperty("message", containsString("Exception in GET request"))));
+            hasProperty("cause", is(nullValue())),
+            hasProperty(
+                "message",
+                containsString(
+                    "Didn't get a 200 response from Stash PR GET! Response; '404' with message; Not Found"))));
   }
 
   @Test
@@ -271,7 +278,7 @@ public class StashApiClientTest {
             StashApiException.class,
             () -> client.getPullRequestComments(projectName, repositoryName, pullRequestId)),
         allOf(
-            hasProperty("cause", is(instanceOf(ExecutionException.class))),
+            hasProperty("cause", is(instanceOf(ClientProtocolException.class))),
             hasProperty("message", containsString("Exception in GET request"))));
   }
 
@@ -284,7 +291,7 @@ public class StashApiClientTest {
             StashApiException.class,
             () -> client.getPullRequestComments(projectName, repositoryName, pullRequestId)),
         allOf(
-            hasProperty("cause", is(instanceOf(ExecutionException.class))),
+            hasProperty("cause", is(instanceOf(SocketException.class))),
             hasProperty("message", containsString("Exception in GET request"))));
   }
 
@@ -311,7 +318,7 @@ public class StashApiClientTest {
             StashApiException.class,
             () -> client.deletePullRequestComment(pullRequestId, commentId)),
         allOf(
-            hasProperty("cause", is(instanceOf(ExecutionException.class))),
+            hasProperty("cause", is(instanceOf(ClientProtocolException.class))),
             hasProperty("message", containsString("Exception in DELETE request"))));
   }
 
@@ -324,7 +331,7 @@ public class StashApiClientTest {
             StashApiException.class,
             () -> client.deletePullRequestComment(pullRequestId, commentId)),
         allOf(
-            hasProperty("cause", is(instanceOf(ExecutionException.class))),
+            hasProperty("cause", is(instanceOf(SocketException.class))),
             hasProperty("message", containsString("Exception in DELETE request"))));
   }
 
@@ -357,8 +364,8 @@ public class StashApiClientTest {
             StashApiException.class,
             () -> client.postPullRequestComment(pullRequestId, "Some comment")),
         allOf(
-            hasProperty("cause", is(instanceOf(ExecutionException.class))),
-            hasProperty("message", containsString("Exception in POST request"))));
+            hasProperty("cause", is(nullValue())),
+            hasProperty("message", containsString("No HTTP entity found in response"))));
   }
 
   @Test
@@ -370,8 +377,11 @@ public class StashApiClientTest {
             StashApiException.class,
             () -> client.postPullRequestComment(pullRequestId, "Some comment")),
         allOf(
-            hasProperty("cause", is(instanceOf(ExecutionException.class))),
-            hasProperty("message", containsString("Exception in POST request"))));
+            hasProperty("cause", is(nullValue())),
+            hasProperty(
+                "message",
+                containsString(
+                    "Didn't get a 200 response from Stash PR POST! Response; '404' with message; Not Found"))));
   }
 
   @Test
@@ -383,7 +393,7 @@ public class StashApiClientTest {
             StashApiException.class,
             () -> client.postPullRequestComment(pullRequestId, "Some comment")),
         allOf(
-            hasProperty("cause", is(instanceOf(ExecutionException.class))),
+            hasProperty("cause", is(instanceOf(Exception.class))),
             hasProperty("message", containsString("Exception in POST request"))));
   }
 
@@ -396,7 +406,7 @@ public class StashApiClientTest {
             StashApiException.class,
             () -> client.postPullRequestComment(pullRequestId, "Some comment")),
         allOf(
-            hasProperty("cause", is(instanceOf(ExecutionException.class))),
+            hasProperty("cause", is(instanceOf(SocketException.class))),
             hasProperty("message", containsString("Exception in POST request"))));
   }
 
@@ -420,8 +430,11 @@ public class StashApiClientTest {
         assertThrows(
             StashApiException.class, () -> client.getPullRequestMergeStatus(pullRequestId)),
         allOf(
-            hasProperty("cause", is(instanceOf(ExecutionException.class))),
-            hasProperty("message", containsString("Exception in GET request"))));
+            hasProperty("cause", is(nullValue())),
+            hasProperty(
+                "message",
+                containsString(
+                    "Didn't get a 200 response from Stash PR GET! Response; '404' with message; Not Found"))));
   }
 
   @Test
@@ -432,7 +445,7 @@ public class StashApiClientTest {
         assertThrows(
             StashApiException.class, () -> client.getPullRequestMergeStatus(pullRequestId)),
         allOf(
-            hasProperty("cause", is(instanceOf(ExecutionException.class))),
+            hasProperty("cause", is(instanceOf(ClientProtocolException.class))),
             hasProperty("message", containsString("Exception in GET request"))));
   }
 
@@ -444,7 +457,7 @@ public class StashApiClientTest {
         assertThrows(
             StashApiException.class, () -> client.getPullRequestMergeStatus(pullRequestId)),
         allOf(
-            hasProperty("cause", is(instanceOf(ExecutionException.class))),
+            hasProperty("cause", is(instanceOf(SocketException.class))),
             hasProperty("message", containsString("Exception in GET request"))));
   }
 
@@ -473,8 +486,8 @@ public class StashApiClientTest {
         assertThrows(
             StashApiException.class, () -> client.mergePullRequest(pullRequestId, mergeVersion)),
         allOf(
-            hasProperty("cause", is(instanceOf(ExecutionException.class))),
-            hasProperty("message", containsString("Exception in POST request"))));
+            hasProperty("cause", is(nullValue())),
+            hasProperty("message", containsString("No HTTP entity found in response"))));
   }
 
   @Test
@@ -494,8 +507,11 @@ public class StashApiClientTest {
         assertThrows(
             StashApiException.class, () -> client.mergePullRequest(pullRequestId, mergeVersion)),
         allOf(
-            hasProperty("cause", is(instanceOf(ExecutionException.class))),
-            hasProperty("message", containsString("Exception in POST request"))));
+            hasProperty("cause", is(nullValue())),
+            hasProperty(
+                "message",
+                containsString(
+                    "Didn't get a 200 response from Stash PR POST! Response; '404' with message; Not Found"))));
   }
 
   @Test
@@ -506,7 +522,7 @@ public class StashApiClientTest {
         assertThrows(
             StashApiException.class, () -> client.mergePullRequest(pullRequestId, mergeVersion)),
         allOf(
-            hasProperty("cause", is(instanceOf(ExecutionException.class))),
+            hasProperty("cause", is(instanceOf(ClientProtocolException.class))),
             hasProperty("message", containsString("Exception in POST request"))));
   }
 
@@ -518,7 +534,7 @@ public class StashApiClientTest {
         assertThrows(
             StashApiException.class, () -> client.mergePullRequest(pullRequestId, mergeVersion)),
         allOf(
-            hasProperty("cause", is(instanceOf(ExecutionException.class))),
+            hasProperty("cause", is(instanceOf(SocketException.class))),
             hasProperty("message", containsString("Exception in POST request"))));
   }
 }


### PR DESCRIPTION
```
*  StashApiClient: Run HTTP requests in the main thread
   
   Using separate threads adds complexity for little benefit. Socket timeout
   should take care of slow HTTP connections.
   
   JENKINS-30558 doesn't provide any evidence that a separate timeout for
   requests was needed. The request timeout and the socket timeout were added
   in the same commit 80431f422dce9ea763e59c28e35fef75113203b1.
   
   This change eliminates ExecutionException as an exception thrown by
   StashApiClient, replacing it with more specific exceptions. Update unit
   tests for the new behavior.
```

This PR depends on #143.