### PR TITLE
[TRIVIAL] Tool updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock-jre8-standalone</artifactId>
-      <version>2.23.2</version>
+      <version>2.24.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
       <plugin>
         <groupId>com.coveo</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.8</version>
+        <version>2.9</version>
         <executions>
           <execution>
             <goals>

--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClientTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClientTest.java
@@ -438,7 +438,7 @@ public class StashApiClientTest {
             .withHeader("Content-Type", absent())
             .withHeader("Connection", equalTo("close"))
             .withHeader("X-Atlassian-Token", equalTo("no-check"))
-            .withRequestBody(equalTo("")));
+            .withRequestBody(absent()));
   }
 
   @Test


### PR DESCRIPTION
I was the one who asked for `absent()` support in WireMock verifications for the request body, so it makes sense to use it once it's available.

`fmt-maven-plugin` 2.9 fixes a serious issue: https://github.com/coveooss/fmt-maven-plugin/issues/42