### PR TITLE
StashBuildTrigger: Fix exception if run() is called after stop()

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -254,7 +254,7 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
 
   @Override
   public void run() {
-    if (job == null) {
+    if (job == null || stashRepository == null) {
       logger.info("Not ready to run.");
       return;
     }


### PR DESCRIPTION
```
*  StashBuildTrigger: Fix exception if run() is called after stop()
   
   Trigger#stop() doesn't set job to null, so having a non-null job doesn't
   guarantee that stashRepository is not null.
```

This should fix the issue reported on Gitter earlier today.