### PR TITLE
Use job.getFullName() in logs, it's unique for every Item in Jenkins

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildListener.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildListener.java
@@ -79,7 +79,7 @@ public class StashBuildListener extends RunListener<Run<?, ?>> {
       buildLogger.println(
           format(
               "%s: cannot delete Build Start comment for pull request %s",
-              run.getParent().getDisplayName(), cause.getPullRequestId()));
+              run.getParent().getFullName(), cause.getPullRequestId()));
       e.printStackTrace(buildLogger);
     }
 

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -272,7 +272,7 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
     }
 
     if (!job.isBuildable()) {
-      logger.fine(format("Job is not buildable, skipping build (%s).", job.getName()));
+      logger.fine(format("Job is not buildable, skipping build (%s).", job.getFullName()));
       return;
     }
 

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -98,7 +98,7 @@ public class StashRepository {
       pullRequests = client.getPullRequests();
     } catch (StashApiException e) {
       pollLog.log("Cannot fetch pull request list", e);
-      logger.log(Level.INFO, format("%s: cannot fetch pull request list", job.getName()), e);
+      logger.log(Level.INFO, format("%s: cannot fetch pull request list", job.getFullName()), e);
       return targetPullRequests;
     }
 
@@ -296,7 +296,7 @@ public class StashRepository {
             Level.INFO,
             format(
                 "%s: cannot read additional parameters for pull request %s, skipping",
-                job.getName(), pullRequest.getId()),
+                job.getFullName(), pullRequest.getId()),
             e);
         continue;
       }
@@ -313,7 +313,7 @@ public class StashRepository {
               Level.INFO,
               format(
                   "%s: cannot delete old \"BuildFinished\" comments for pull request %s",
-                  job.getName(), pullRequest),
+                  job.getFullName(), pullRequest),
               e);
         }
       }
@@ -336,7 +336,7 @@ public class StashRepository {
             Level.INFO,
             format(
                 "%s: cannot post Build Start comment for pull request %s, not building",
-                job.getName(), pullRequest.getId()),
+                job.getFullName(), pullRequest.getId()),
             e);
         continue;
       }
@@ -433,7 +433,7 @@ public class StashRepository {
           Level.WARNING,
           format(
               "%s: cannot post Build Finished comment for pull request %s",
-              job.getDisplayName(), pullRequestId),
+              job.getFullName(), pullRequestId),
           e);
     }
   }
@@ -559,7 +559,7 @@ public class StashRepository {
           Level.INFO,
           format(
               "%s: cannot determine if pull request %s can be merged, skipping",
-              job.getDisplayName(), pullRequest.getId()),
+              job.getFullName(), pullRequest.getId()),
           e);
       return false;
     }
@@ -586,7 +586,7 @@ public class StashRepository {
     try {
       comments = client.getPullRequestComments(owner, repositoryName, id);
     } catch (StashApiException e) {
-      logger.log(Level.INFO, format("%s: cannot read pull request comments", job.getName()), e);
+      logger.log(Level.INFO, format("%s: cannot read pull request comments", job.getFullName()), e);
       return false;
     }
 

--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepositoryTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepositoryTest.java
@@ -223,7 +223,7 @@ public class StashRepositoryTest {
     when(stashApiClient.getPullRequests()).thenReturn(pullRequestList);
     when(trigger.getCiSkipPhrases()).thenReturn("NO TEST");
     when(stashApiClient.getPullRequestComments(any(), any(), any())).thenReturn(comments);
-    when(project.getDisplayName()).thenReturn("Pull Request Builder Project");
+    when(project.getFullName()).thenReturn("Pull Request Builder Project");
 
     assertThat(stashRepository.getTargetPullRequests(), empty());
   }
@@ -244,7 +244,7 @@ public class StashRepositoryTest {
     when(trigger.getCiSkipPhrases()).thenReturn("NO TEST");
     when(trigger.getCiBuildPhrases()).thenReturn("DO TEST");
     when(stashApiClient.getPullRequestComments(any(), any(), any())).thenReturn(comments);
-    when(project.getDisplayName()).thenReturn("Pull Request Builder Project");
+    when(project.getFullName()).thenReturn("Pull Request Builder Project");
 
     assertThat(stashRepository.getTargetPullRequests(), contains(pullRequest));
   }
@@ -367,7 +367,7 @@ public class StashRepositoryTest {
 
     when(trigger.getDeletePreviousBuildFinishComments()).thenReturn(true);
     when(trigger.getStashHost()).thenReturn("StashHost");
-    when(project.getDisplayName()).thenReturn("MyProject");
+    when(project.getFullName()).thenReturn("MyProject");
 
     pullRequest.setId("123");
     stashRepository.addFutureBuildTasks(pullRequestList);
@@ -392,7 +392,7 @@ public class StashRepositoryTest {
 
     when(trigger.getDeletePreviousBuildFinishComments()).thenReturn(true);
     when(trigger.getStashHost()).thenReturn("http://localhost/");
-    when(project.getDisplayName()).thenReturn("MyProject");
+    when(project.getFullName()).thenReturn("MyProject");
     doThrow(new StashApiException("Cannot Delete"))
         .when(stashApiClient)
         .deletePullRequestComment(any(), any());


### PR DESCRIPTION
```
*  Use job.getFullName() in logs, it's unique for every Item in Jenkins
   
   It is more important to be precise in logs than to show user defined
   display names. Display names can be changed easily in the configuration,
   making the logs hard to interpret.
   
   Leave job.getDisplayName() for Stash comments. Stop using job.getName().
```

Other plugins tend to use `getFullName` in logs. It's good to standardize on something as the logging is being reworked.