### PR TITLE
Use dependency injection for StashRepository

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -19,7 +19,6 @@ import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
 import hudson.util.ListBoxModel;
 import java.lang.invoke.MethodHandles;
-import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.ParameterizedJobMixIn.ParameterizedJob;
@@ -235,12 +234,16 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
   public void start(Job<?, ?> job, boolean newInstance) {
     super.start(job, newInstance);
 
+    if (job == null) {
+      logger.log(Level.SEVERE, "Can't start trigger: job is null");
+      return;
+    }
+
     if (stashPollingAction == null) {
       stashPollingAction = new StashPollingAction(job);
     }
 
     try {
-      Objects.requireNonNull(job, "job is null");
       StashApiClient stashApiClient =
           new StashApiClient(
               getStashHost(),
@@ -251,7 +254,7 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
               getIgnoreSsl());
 
       this.stashRepository = new StashRepository(job, this, stashApiClient);
-    } catch (NullPointerException e) {
+    } catch (Throwable e) {
       logger.log(Level.SEVERE, "Can't start trigger", e);
       stashPollingAction.log("Can't start trigger", e);
     }

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -29,6 +29,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
+import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashApiClient;
 
 /** Created by Nathan McCarthy */
 public class StashBuildTrigger extends Trigger<Job<?, ?>> {
@@ -240,8 +241,16 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
 
     try {
       Objects.requireNonNull(job, "job is null");
-      this.stashRepository = new StashRepository(job, this);
+      StashApiClient stashApiClient =
+          new StashApiClient(
+              getStashHost(),
+              getUsername(),
+              getPassword(),
+              getProjectCode(),
+              getRepositoryName(),
+              getIgnoreSsl());
 
+      this.stashRepository = new StashRepository(job, this, stashApiClient);
     } catch (NullPointerException e) {
       logger.log(Level.SEVERE, "Can't start trigger", e);
       stashPollingAction.log("Can't start trigger", e);

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -71,26 +71,11 @@ public class StashRepository {
 
   private long pollStartTime;
 
-  public StashRepository(@Nonnull Job<?, ?> job, @Nonnull StashBuildTrigger trigger) {
-    this(job, trigger, makeStashApiClient(trigger));
-  }
-
-  // Visible for unit tests
-  StashRepository(
+  public StashRepository(
       @Nonnull Job<?, ?> job, @Nonnull StashBuildTrigger trigger, StashApiClient client) {
     this.job = job;
     this.trigger = trigger;
     this.client = client;
-  }
-
-  private static StashApiClient makeStashApiClient(StashBuildTrigger trigger) {
-    return new StashApiClient(
-        trigger.getStashHost(),
-        trigger.getUsername(),
-        trigger.getPassword(),
-        trigger.getProjectCode(),
-        trigger.getRepositoryName(),
-        trigger.getIgnoreSsl());
   }
 
   private static String logTimestamp() {

--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepositoryTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepositoryTest.java
@@ -1,13 +1,5 @@
 package stashpullrequestbuilder.stashpullrequestbuilder;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.arrayWithSize;
@@ -26,7 +18,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import hudson.model.BooleanParameterDefinition;
 import hudson.model.FileParameterDefinition;
 import hudson.model.FreeStyleProject;
@@ -66,7 +57,6 @@ public class StashRepositoryTest {
 
   @Rule public JenkinsRule jenkinsRule = new JenkinsRule();
   @Rule public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
-  @Rule public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
 
   private StashRepository stashRepository;
 
@@ -564,28 +554,5 @@ public class StashRepositoryTest {
     stashRepository.addFutureBuildTasks(pullRequestList);
 
     assertThat(Jenkins.getInstance().getQueue().getItems(), is(emptyArray()));
-  }
-
-  @Test
-  public void constructor_initializes_StashApiClient() throws Exception {
-    String projectName = "PROJ";
-    String repositoryName = "Repo";
-
-    when(trigger.getStashHost()).thenReturn(wireMockRule.baseUrl());
-    when(trigger.getUsername()).thenReturn("User");
-    when(trigger.getPassword()).thenReturn("Password");
-    when(trigger.getProjectCode()).thenReturn(projectName);
-    when(trigger.getRepositoryName()).thenReturn(repositoryName);
-    when(trigger.getIgnoreSsl()).thenReturn(false);
-
-    stubFor(
-        get(format(
-                "/rest/api/1.0/projects/%s/repos/%s/pull-requests?start=0",
-                projectName, repositoryName))
-            .willReturn(okJson("{\"isLastPage\": true, \"values\": []}")));
-
-    StashRepository newStashRepository = new StashRepository(project, trigger);
-    assertThat(newStashRepository.getTargetPullRequests(), is(empty()));
-    verify(getRequestedFor(anyUrl()));
   }
 }


### PR DESCRIPTION
Decouple `StashApiClient` from `StashRepository`. Improve exception handling in `StashBuildTrigger#start()` to make it better equipped for dealing with multiple constructors.