### PR TITLE
Make poll log available everywhere in StashRepository, use it more

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -253,7 +253,7 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
               getRepositoryName(),
               getIgnoreSsl());
 
-      this.stashRepository = new StashRepository(job, this, stashApiClient);
+      this.stashRepository = new StashRepository(job, this, stashApiClient, stashPollingAction);
     } catch (Throwable e) {
       logger.log(Level.SEVERE, "Can't start trigger", e);
       stashPollingAction.log("Can't start trigger", e);

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -529,16 +529,15 @@ public class StashRepository {
     boolean shouldBuild = true;
 
     if (isSkipBuild(pullRequest.getTitle())) {
-      logger.info("Skipping PR: " + pullRequest.getId() + " as title contained skip phrase");
+      pollLog.log("Not building PR #{}, its title contains the skip phrase", pullRequest.getId());
       return false;
     }
 
     if (!isForTargetBranch(pullRequest)) {
-      logger.info(
-          "Skipping PR: "
-              + pullRequest.getId()
-              + " as targeting branch: "
-              + pullRequest.getToRef().getBranch().getName());
+      pollLog.log(
+          "Not building PR #{} as it targets branch {}",
+          pullRequest.getId(),
+          pullRequest.getToRef().getBranch().getName());
       return false;
     }
 
@@ -547,7 +546,7 @@ public class StashRepository {
     // the pull request in this cycle.
     try {
       if (!isPullRequestMergeable(pullRequest)) {
-        logger.info("Skipping PR: " + pullRequest.getId() + " as cannot be merged");
+        pollLog.log("Not building PR #{} as it cannot be merged", pullRequest.getId());
         return false;
       }
     } catch (StashApiException e) {

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -551,6 +551,7 @@ public class StashRepository {
         return false;
       }
     } catch (StashApiException e) {
+      pollLog.log("Cannot determine if PR #{} can be merged, not building", pullRequest.getId(), e);
       logger.log(
           Level.INFO,
           format(
@@ -582,6 +583,7 @@ public class StashRepository {
     try {
       comments = client.getPullRequestComments(owner, repositoryName, id);
     } catch (StashApiException e) {
+      pollLog.log("Cannot read comments for PR #{}, not building", pullRequest.getId(), e);
       logger.log(Level.INFO, format("%s: cannot read pull request comments", job.getFullName()), e);
       return false;
     }


### PR DESCRIPTION
```
*  StashRepository: Take pollLog as a constructor argument
   
   Move the code that logs common information (start and stop time,
   duration, number of pull requests) to pollRepository(). Add a unit test
   to check that the common information is being logged.

*  StashRepository: Log exceptions to the poll log and to the system log
   
   Even users without administrative access should know if their PRs are not
   built due to an exception.

*  StashRepository: Log triggering decisions to the poll log only
   
   If a message explains why a PR is not being built, log it to the poll log
   only, unless it's caused by an exception.
   
   Triggering decisions depend on the state of the PR and don't appear and
   disappear on their own. It is not of much interest why a PR wasn't built
   in the past.
   
   No need to fill logs with messages about pull requests that cannot be
   merged for every polling cycle.
```