### PR TITLE
Escape user-supplied values when setting build description

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,21 @@
       <version>4.5.5-3.0</version>
     </dependency>
     <dependency>
+      <groupId>org.owasp.esapi</groupId>
+      <artifactId>esapi</artifactId>
+      <version>2.2.0.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4jVersion}</version>

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashCause.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashCause.java
@@ -1,8 +1,12 @@
 package stashpullrequestbuilder.stashpullrequestbuilder;
 
 import hudson.model.Cause;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.TreeMap;
+import org.owasp.esapi.Encoder;
+import org.owasp.esapi.reference.DefaultEncoder;
 
 /** Created by Nathan McCarthy */
 public class StashCause extends Cause {
@@ -123,18 +127,38 @@ public class StashCause extends Cause {
 
   @Override
   public String getShortDescription() {
-    return "<a href=\""
-        + stashHost
-        + "/projects/"
-        + this.getDestinationRepositoryOwner()
-        + "/repos/"
-        + this.getDestinationRepositoryName()
-        + "/pull-requests/"
-        + this.getPullRequestId()
-        + "\" >PR #"
-        + this.getPullRequestId()
-        + " "
-        + this.getPullRequestTitle()
-        + " </a>";
+    return "<a href='" + getEscapedUrl() + "'>" + getEscapedDescription() + " </a>";
+  }
+
+  String getEscapedUrl() {
+    return getEncoder().encodeForHTMLAttribute(getPrUrl().toASCIIString());
+  }
+
+  String getEscapedDescription() {
+    return getEncoder()
+        .encodeForHTML("PR #" + this.getPullRequestId() + " " + this.getPullRequestTitle());
+  }
+
+  URI getPrUrl() {
+    try {
+      return new URI(stashHost)
+          .resolve(
+              new URI(
+                  null,
+                  null,
+                  "/projects/"
+                      + this.getDestinationRepositoryOwner()
+                      + "/repos/"
+                      + this.getDestinationRepositoryName()
+                      + "/pull-requests/"
+                      + this.getPullRequestId(),
+                  null));
+    } catch (URISyntaxException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private static Encoder getEncoder() {
+    return DefaultEncoder.getInstance();
   }
 }

--- a/src/main/resources/ESAPI.properties
+++ b/src/main/resources/ESAPI.properties
@@ -1,0 +1,1 @@
+ESAPI.Encoder=org.owasp.esapi.reference.DefaultEncoder

--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashCauseTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashCauseTest.java
@@ -1,0 +1,119 @@
+package stashpullrequestbuilder.stashpullrequestbuilder;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.object.HasToString.hasToString;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class StashCauseTest {
+
+  @Test
+  public void short_description_doesnt_allow_injection() {
+
+    StashCause stashCause =
+        new StashCause(
+            "",
+            "",
+            "",
+            "",
+            "",
+            PULL_REQUEST_ID,
+            OWNER,
+            DESTINATION_REPOSITORY_NAME,
+            PULL_REQUEST_TITLE,
+            "",
+            "",
+            "",
+            "",
+            null);
+
+    assertThat(
+        stashCause.getShortDescription(),
+        is(
+            "<a href='&#x2f;projects&#x2f;owner&#x25;3C&#x25;3E&amp;&#x27;&#x25;22&#x2f;repos&#x2f;name&#x25;3C&#x25;3E&amp;&#x27;&#x25;22&#x2f;pull-requests&#x2f;id&#x25;3C&#x25;3E&amp;&#x27;&#x25;22'>"
+                + "PR &#x23;id&lt;&gt;&amp;&#x27;&quot; title&lt;&gt;&amp;&#x27;&quot; </a>"));
+  }
+
+  @Test
+  public void will_produce_valid_PR_url() {
+
+    StashCause stashCause =
+        new StashCause(
+            "https://stash.host",
+            "",
+            "",
+            "",
+            "",
+            PULL_REQUEST_ID,
+            OWNER,
+            DESTINATION_REPOSITORY_NAME,
+            PULL_REQUEST_TITLE,
+            "",
+            "",
+            "",
+            "",
+            null);
+
+    assertThat(
+        stashCause.getPrUrl(),
+        hasToString(
+            "https://stash.host/projects/owner%3C%3E&'%22/repos/name%3C%3E&'%22/pull-requests/id%3C%3E&'%22"));
+  }
+
+  @Test
+  public void will_escape_PR_url() {
+
+    StashCause stashCause =
+        new StashCause(
+            "https://stash.host",
+            "",
+            "",
+            "",
+            "",
+            PULL_REQUEST_ID,
+            OWNER,
+            DESTINATION_REPOSITORY_NAME,
+            PULL_REQUEST_TITLE,
+            "",
+            "",
+            "",
+            "",
+            null);
+
+    assertThat(
+        stashCause.getEscapedUrl(),
+        is(
+            "https&#x3a;&#x2f;&#x2f;stash.host&#x2f;projects&#x2f;owner&#x25;3C&#x25;3E&amp;&#x27;&#x25;22&#x2f;repos&#x2f;name&#x25;3C&#x25;3E&amp;&#x27;&#x25;22&#x2f;pull-requests&#x2f;id&#x25;3C&#x25;3E&amp;&#x27;&#x25;22"));
+  }
+
+  @Test
+  public void will_escape_PR_description() {
+
+    StashCause stashCause =
+        new StashCause(
+            "https://stash.host",
+            "",
+            "",
+            "",
+            "",
+            PULL_REQUEST_ID,
+            OWNER,
+            DESTINATION_REPOSITORY_NAME,
+            PULL_REQUEST_TITLE,
+            "",
+            "",
+            "",
+            "",
+            null);
+
+    assertThat(
+        stashCause.getEscapedDescription(),
+        is("PR &#x23;id&lt;&gt;&amp;&#x27;&quot; title&lt;&gt;&amp;&#x27;&quot;"));
+  }
+
+  public static final String OWNER = "owner<>&'\"";
+  public static final String DESTINATION_REPOSITORY_NAME = "name<>&'\"";
+  public static final String PULL_REQUEST_ID = "id<>&'\"";
+  public static final String PULL_REQUEST_TITLE = "title<>&'\"";
+}


### PR DESCRIPTION
@proski I wonder WDYT about this change.
This is a hack to cover a common case when using a html-enabled markup formatted.

However I've learned that updating build description the way this plugin does it now is fundamentally wrong. It should be instead adding a build badge. Build badges also have an API to make it easier to escape input for html.