### PR TITLE
pom.xml: Use GitHub for plugin's documentation on plugins.jenkins.io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <name>Stash Pullrequest Builder Plugin</name>
   <description>This plugin builds Stash pull requests and posts the build results on Stash</description>
-  <url>https://wiki.jenkins.io/display/JENKINS/Stash+pullrequest+builder+plugin</url>
+  <url>https://github.com/jenkinsci/stash-pullrequest-builder-plugin</url>
 
   <developers>
     <developer>


### PR DESCRIPTION
This fixes duplication of the documentation between the plugin sources
and the plugin website.

See https://groups.google.com/forum/#!topic/jenkinsci-dev/VSdfVMDIW-A and
https://issues.jenkins-ci.org/browse/WEBSITE-406 for details.