### PR TITLE
Unwatch PR after posting any comment

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
@@ -158,8 +158,7 @@ public class StashApiClient {
     }
   }
 
-  public void stopWatchingPullRequest(String pullRequestId)
-      throws StashApiException {
+  public void stopWatchingPullRequest(String pullRequestId) throws StashApiException {
     String path = pullRequestPath(pullRequestId) + "/watch";
     deleteRequest(path);
   }

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
@@ -150,11 +150,18 @@ public class StashApiClient {
       throws StashApiException {
     String path = pullRequestPath(pullRequestId) + "/comments";
     String response = postRequest(path, comment);
+    stopWatchingPullRequest(pullRequestId);
     try {
       return parseSingleCommentJson(response);
     } catch (IOException e) {
       throw new StashApiException("Cannot parse reply after comment posting", e);
     }
+  }
+
+  public void stopWatchingPullRequest(String pullRequestId)
+      throws StashApiException {
+    String path = pullRequestPath(pullRequestId) + "/watch";
+    deleteRequest(path);
   }
 
   @Nullable

--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClientTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClientTest.java
@@ -93,6 +93,12 @@ public class StashApiClientTest {
         projectName, repositoryName, pullRequestId);
   }
 
+  private String pullRequestWatchPath() {
+    return format(
+        "/rest/api/1.0/projects/%s/repos/%s/pull-requests/%s/watch",
+        projectName, repositoryName, pullRequestId);
+  }
+
   private String pullRequestMergeStatusPath() {
     return format(
         "/rest/api/1.0/projects/%s/repos/%s/pull-requests/%s/merge",
@@ -323,6 +329,7 @@ public class StashApiClientTest {
         post(pullRequestPostCommentPath())
             .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
             .willReturn(jsonResponse("PostPullRequestComment.json")));
+    stubFor(delete(pullRequestWatchPath()).willReturn(noContent()));
 
     StashPullRequestComment comment = client.postPullRequestComment(pullRequestId, "Some comment");
     assertThat(comment.getCommentId(), is(234));


### PR DESCRIPTION
Hi,

When a user adds a comment to a Stash PR, it also makes that user "watch" that PR and receive all further updates. In our org, the service user's email address is a large ML, and most people are not interested in having updates for all PR. I haven't found a setting in Stash to allow posting comments without subscribing as a watcher. The next best thing is to "unwatch" the PR after every comment posting.
