### PR TITLE
StashApiClientTest: Fix tests on systems that listen to HTTP port 8080

### DIFF
--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClientTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClientTest.java
@@ -52,7 +52,10 @@ import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashApiClient.Stas
 public class StashApiClientTest {
 
   @Rule public ExpectedException expectedException = ExpectedException.none();
-  @Rule public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicHttpsPort());
+
+  @Rule
+  public WireMockRule wireMockRule =
+      new WireMockRule(wireMockConfig().dynamicPort().dynamicHttpsPort());
 
   private StashApiClient client;
 


### PR DESCRIPTION
WireMock listens to HTTP port 8080 by default, even if HTTPS port is
dynamic and no tests use HTTP. Use dynamic ports both for HTTP and HTTPS.