### PR TITLE
[JENKINS-59833] Prevent unwanted folding of multiple queue tasks into one

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashQueueAction.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashQueueAction.java
@@ -1,0 +1,29 @@
+package stashpullrequestbuilder.stashpullrequestbuilder;
+
+import hudson.model.Action;
+import hudson.model.InvisibleAction;
+import hudson.model.Queue.QueueAction;
+import java.util.List;
+
+/**
+ * QueueAction implementation used to control folding of queue items
+ *
+ * <p>Jenkins tries to fold multiple queue items into one to avoid building the same thing multiple
+ * times. That behavior is undesired for the builds triggered by this plugin. The builds differ by
+ * StashCause, but Jenkins allows a build to have many causes.
+ *
+ * <p>Jenkins uses QueueAction interface to decide whether to fold tasks. Tasks that use this action
+ * will not be folded by Jenkins.
+ */
+public class StashQueueAction extends InvisibleAction implements QueueAction {
+
+  /**
+   * Returns whether the new item should be scheduled. Returns true if the other task is 'different
+   * enough' to warrant a separate execution.
+   */
+  @Override
+  public boolean shouldSchedule(List<Action> actions) {
+    // Always schedule a new task
+    return true;
+  }
+}

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -275,7 +275,7 @@ public class StashRepository {
     }
 
     return ParameterizedJobMixIn.scheduleBuild2(
-        job, -1, new CauseAction(cause), new ParametersAction(values));
+        job, -1, new CauseAction(cause), new StashQueueAction(), new ParametersAction(values));
   }
 
   public void addFutureBuildTasks(Collection<StashPullRequestResponseValue> pullRequests) {


### PR DESCRIPTION
```
*  [JENKINS-59833] Prevent unwanted folding of multiple queue tasks into one
   
   Add StashQueueAction class that always requests a new task to be
   scheduled.
```

This is a minimal change to fix the bug.

I'm not trying to incorporate any advance logic to fold builds for the same PR. It can be done separately. The assumption was that Jenkins doesn't fold tasks. I'm just trying to make Jenkins work according to that assumption.

Please merge it soon and make a release. It's a bad bug that can strike unexpectedly when multiple PRs become ready for build during the same polling interval.