### PR TITLE
Fix error handling when merging pull requests

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -442,10 +443,12 @@ public class StashRepository {
    *
    * @param pullRequestId pull request ID
    * @param version pull request version
-   * @return true if the merge succeeds, false if the server reports an error
+   * @return empty optional if the merge succeeds, server response otherwise
    * @throws StashApiException if cannot communicate to the server
    */
-  public boolean mergePullRequest(String pullRequestId, String version) throws StashApiException {
+  @Nonnull
+  public Optional<String> mergePullRequest(String pullRequestId, String version)
+      throws StashApiException {
     return this.client.mergePullRequest(pullRequestId, version);
   }
 

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
@@ -13,6 +13,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
@@ -169,10 +170,26 @@ public class StashApiClient {
     }
   }
 
-  public boolean mergePullRequest(String pullRequestId, String version) throws StashApiException {
+  @Nonnull
+  public Optional<String> mergePullRequest(String pullRequestId, String version)
+      throws StashApiException {
     String path = pullRequestPath(pullRequestId) + "/merge?version=" + version;
     String response = postRequest(path, null);
-    return !response.equals(Integer.toString(HttpStatus.SC_CONFLICT));
+
+    try {
+      StashPullRequestResponseValue parsedResponse =
+          mapper.readValue(response, StashPullRequestResponseValue.class);
+
+      if ("MERGED".equals(parsedResponse.getState())) {
+        // Successful merge
+        return Optional.empty();
+      }
+    } catch (IOException e) {
+      throw new StashApiException("Cannot parse merge response", e);
+    }
+
+    // Return the whole response for the purpose of logging
+    return Optional.ofNullable(response);
   }
 
   private CloseableHttpClient getHttpClient() throws StashApiException {
@@ -423,7 +440,8 @@ public class StashApiClient {
         || responseCode == HttpStatus.SC_ACCEPTED
         || responseCode == HttpStatus.SC_CREATED
         || responseCode == HttpStatus.SC_NO_CONTENT
-        || responseCode == HttpStatus.SC_RESET_CONTENT;
+        || responseCode == HttpStatus.SC_RESET_CONTENT
+        || responseCode == HttpStatus.SC_CONFLICT;
   }
 
   private StashPullRequestResponse parsePullRequestJson(String response) throws IOException {

--- a/src/test/resources/__files/PullRequestMergeFailed.json
+++ b/src/test/resources/__files/PullRequestMergeFailed.json
@@ -1,0 +1,9 @@
+{
+  "errors" : [
+    {
+      "context" : null,
+      "exceptionName" : null,
+      "message" : "A detailed error message."
+    }
+  ]
+}

--- a/src/test/resources/__files/PullRequestMerged.json
+++ b/src/test/resources/__files/PullRequestMerged.json
@@ -1,0 +1,38 @@
+{
+  "closed" : false,
+  "createdDate" : "2017/11/20 8:20:59",
+  "description" : "Expand code to make it slower",
+  "fromRef" : {
+    "branch" : {
+      "name" : "MadeFromId"
+    },
+    "id" : "refs/heads/abc",
+    "latestChangeset" : "13",
+    "latestCommit" : "DCBA",
+    "repository" : {
+      "project" : {
+        "key" : "MyClone"
+      },
+      "slug" : "~Me"
+    }
+  },
+  "id" : "1001",
+  "locked" : false,
+  "state" : "MERGED",
+  "title" : "Add some bloat",
+  "toRef" : {
+    "branch" : {
+      "Name" : "Incorrect",
+      "name" : "master"
+    },
+    "latestCommit" : "ABCD",
+    "repository" : {
+      "project" : {
+        "key" : "PROJ"
+      },
+      "slug" : "BigRepo"
+    }
+  },
+  "updatedDate" : "2018/02/03 15:33:14",
+  "version" : "3.11"
+}


### PR DESCRIPTION
```
*  Fix error handling when merging pull requests

   Treat HTTP code 409 as valid. That makes it possible to process the
   responses sent with that code.

   Parse the response to the merge call as a pull request. If it succeeds
   and the pull request state is "MERGED", return "MERGED". Otherwise,
   return the server response as a string and write it to the build log.
```