### PR TITLE
[BUGFIX] StashRepository: Only cancel queue items for the same job

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -32,6 +32,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import jenkins.model.Jenkins;
 import jenkins.model.ParameterizedJobMixIn;
+import jenkins.model.ParameterizedJobMixIn.ParameterizedJob;
 import org.apache.commons.lang.StringUtils;
 import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashApiClient;
 import stashpullrequestbuilder.stashpullrequestbuilder.stash.StashApiClient.StashApiException;
@@ -209,9 +210,11 @@ public class StashRepository {
   private void cancelPreviousJobsInQueueThatMatch(@Nonnull StashCause stashCause) {
     logger.fine("Looking for queued jobs that match PR ID: " + stashCause.getPullRequestId());
     Queue queue = Jenkins.getInstance().getQueue();
-    for (Queue.Item item : queue.getItems()) {
+
+    // Cast is safe due to StashBuildTrigger#isApplicable() check
+    for (Queue.Item item : queue.getItems((ParameterizedJob) job)) {
       if (hasCauseFromTheSamePullRequest(item.getCauses(), stashCause)) {
-        logger.info("Canceling item in queue: " + item);
+        logger.info(format("%s: canceling item in queue: %s", job.getFullName(), item));
         queue.cancel(item);
       }
     }


### PR DESCRIPTION
```
*  StashRepository: Only cancel queue items for the same job
   
   One repository can use multiple pull request builders. Don't let them
   cancel each other's queue items when "cancel outdated jobs" is enabled.
   
   Log the job name when canceling a queue item.
```

This issue was actually detected as a bug on a production system. Two Jenkins projects were used with the same repository, one to build the code, another to check code coverage. Both would leave comments on the PR page that they were starting. Only one would finish, another would go missing. The log would show that it was canceled, but without any useful context.

A better fix would be to utilize `StashQueueAction`, but I want to provide a simple solution to get that bug fixed quickly.

The workaround is to disable "cancel outdated jobs" in both projects.