### PR TITLE
StashApiClient: Use Iterable instead of List as argument when possible

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
@@ -440,7 +440,7 @@ public class StashApiClient {
 
   @Nonnull
   private List<StashPullRequestComment> extractComments(
-      List<StashPullRequestActivityResponse> responses) {
+      Iterable<StashPullRequestActivityResponse> responses) {
     List<StashPullRequestComment> comments = new ArrayList<>();
     for (StashPullRequestActivityResponse parsedResponse : responses) {
       for (StashPullRequestActivity a : parsedResponse.getPrValues()) {


### PR DESCRIPTION
Suggested by fb-contrib plugin for SpotBugs.