### PR TITLE
StashPullRequestResponseValueRepositoryRepository: Remove useless null check

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValueRepositoryRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestResponseValueRepositoryRepository.java
@@ -2,6 +2,7 @@ package stashpullrequestbuilder.stashpullrequestbuilder.stash;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nullable;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StashPullRequestResponseValueRepositoryRepository {
@@ -26,8 +27,9 @@ public class StashPullRequestResponseValueRepositoryRepository {
     this.slug = slug;
   }
 
+  @Nullable
   public String getProjectName() {
-    if (this.project != null && project.getKey() != null) {
+    if (this.project != null) {
       return project.getKey();
     }
     return null;


### PR DESCRIPTION
Whether project.getKey() is null or not, getProjectName() would return
project.getKey().

Mark getProjectName() as Nullable.