### PR TITLE
StashCause: Generate environment on demand, don't keep it

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashCause.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashCause.java
@@ -20,7 +20,6 @@ public class StashCause extends Cause {
   private final String pullRequestVersion;
   private final String stashHost;
   private final Map<String, String> additionalParameters;
-  private final transient Map<String, String> environmentVariables;
 
   public StashCause(
       String stashHost,
@@ -51,18 +50,6 @@ public class StashCause extends Cause {
     this.pullRequestVersion = pullRequestVersion;
     this.stashHost = stashHost.replaceAll("/$", "");
     this.additionalParameters = additionalParameters;
-
-    environmentVariables = new TreeMap<>();
-    environmentVariables.put("sourceBranch", sourceBranch);
-    environmentVariables.put("targetBranch", targetBranch);
-    environmentVariables.put("sourceRepositoryOwner", sourceRepositoryOwner);
-    environmentVariables.put("sourceRepositoryName", sourceRepositoryName);
-    environmentVariables.put("pullRequestId", pullRequestId);
-    environmentVariables.put("destinationRepositoryOwner", destinationRepositoryOwner);
-    environmentVariables.put("destinationRepositoryName", destinationRepositoryName);
-    environmentVariables.put("pullRequestTitle", pullRequestTitle);
-    environmentVariables.put("sourceCommitHash", sourceCommitHash);
-    environmentVariables.put("destinationCommitHash", destinationCommitHash);
   }
 
   public String getSourceBranch() {
@@ -118,6 +105,22 @@ public class StashCause extends Cause {
   }
 
   public Map<String, String> getEnvironmentVariables() {
+    // Don't keep this map in a member variable, as it would duplicate data
+    // already saved as individual fields. Transient variables are not saved,
+    // but they are lost on Jenkins restart.
+    Map<String, String> environmentVariables = new TreeMap<>();
+
+    environmentVariables.put("sourceBranch", sourceBranch);
+    environmentVariables.put("targetBranch", targetBranch);
+    environmentVariables.put("sourceRepositoryOwner", sourceRepositoryOwner);
+    environmentVariables.put("sourceRepositoryName", sourceRepositoryName);
+    environmentVariables.put("pullRequestId", pullRequestId);
+    environmentVariables.put("destinationRepositoryOwner", destinationRepositoryOwner);
+    environmentVariables.put("destinationRepositoryName", destinationRepositoryName);
+    environmentVariables.put("pullRequestTitle", pullRequestTitle);
+    environmentVariables.put("sourceCommitHash", sourceCommitHash);
+    environmentVariables.put("destinationCommitHash", destinationCommitHash);
+
     return environmentVariables;
   }
 


### PR DESCRIPTION
```
*  StashCause: Generate environment on demand, don't keep it
   
   A transient map is lost on Jenkins restart for queue items. That was
   causing a null pointer exception in StashBuildEnvironmentContributor.
   
   If the environment was kept as a non-transient map, it would be saved to
   build.xml, duplicating already saved information from individual
   StashCause fields.
```