### PR TITLE
Make happy-case Jenkins log messages more useful

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildListener.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildListener.java
@@ -27,12 +27,15 @@ public class StashBuildListener extends RunListener<Run<?, ?>> {
 
   @Override
   public void onStarted(Run<?, ?> run, TaskListener listener) {
-    logger.info("BuildListener onStarted called.");
-
     StashCause cause = run.getCause(StashCause.class);
     if (cause == null) {
       return;
     }
+
+    logger.info(
+        format(
+            "%s started for PR #%s, commit %s",
+            run, cause.getPullRequestId(), cause.getSourceCommitHash()));
 
     try {
       run.setDescription(cause.getShortDescription());

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -366,8 +366,11 @@ public class StashRepository {
       Queue.Item item = startJob(cause);
       if (item != null) {
         pollLog.log("Queued job for PR #{}", pullRequest.getId());
+        logger.info(format("%s: queued job for PR #%s", job.getFullName(), pullRequest.getId()));
       } else {
         pollLog.log("Failed to queue job for PR #{}", pullRequest.getId());
+        logger.warning(
+            format("%s: failed to queue job for PR #%s", job.getFullName(), pullRequest.getId()));
       }
     }
 
@@ -655,9 +658,7 @@ public class StashRepository {
         break;
       }
     }
-    if (shouldBuild) {
-      logger.info("Building PR: " + pullRequest.getId());
-    }
+
     return shouldBuild;
   }
 


### PR DESCRIPTION
```
*  StashBuildListener: Make logging in onStarted() more informative
   
   That's one of the few log messages at the INFO level for the happy case,
   so it should provide more details.
   
   Log the run (that includes the job name and the build number), the pull
   request ID and the commit hash to be tested.

*  StashRepository: Improve logging when a job is queued
   
   Log the full name of the job, as it cannot be easily found from the
   Jenkins log. Move logging next to the corresponding poll log calls.
   
   If the job cannot be queued, use the WARNING log level.
```
Example
```
Before:
2019-11-24 00:08:01.752+0000 [id=46]    INFO    s.s.StashRepository#isBuildTarget: Building PR: 57
2019-11-24 00:08:11.609+0000 [id=51]    INFO    s.s.StashBuildListener#onStarted: BuildListener onStarted called.
2019-11-24 00:09:42.419+0000 [id=51]    INFO    hudson.model.Run#execute: TestRepository_Freestyle_PR_Builder #15 main build action completed: SUCCESS

After:
2019-11-24 05:58:01.710+0000 [id=52]    INFO    s.s.StashRepository#addFutureBuildTasks: TestRepository_Freestyle_PR_Builder: queued job for PR #57
2019-11-24 05:58:08.930+0000 [id=53]    INFO    s.s.StashBuildListener#onStarted: TestRepository_Freestyle_PR_Builder #21 started for PR #57, commit b15996f7a9b3878cdcd5f4bc2c08fe200bac0867
2019-11-24 05:58:09.661+0000 [id=53]    INFO    hudson.model.Run#execute: TestRepository_Freestyle_PR_Builder #21 main build action completed: SUCCESS
```
See how everything can be tied together now. From the job name, I know the repository name. I know which PR in that repository is being built. I know the number of that build. And I can connect the success message to the PR number using the build number. All that is quite challenging with the existing code.