### PR TITLE
Enable more SpotBugs checks, ignore known issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <java.level>8</java.level>
     <jenkins.version>2.60.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
-    <spotbugs.threshold>Medium</spotbugs.threshold>
+    <spotbugs.threshold>Low</spotbugs.threshold>
   </properties>
 
   <dependencies>
@@ -130,6 +130,24 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <plugins>
+            <plugin>
+              <groupId>com.h3xstream.findsecbugs</groupId>
+              <artifactId>findsecbugs-plugin</artifactId>
+              <version>1.10.1</version>
+            </plugin>
+            <plugin>
+              <groupId>com.mebigfatguy.sb-contrib</groupId>
+              <artifactId>sb-contrib</artifactId>
+              <version>7.4.7</version>
+            </plugin>
+          </plugins>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>com.github.ekryd.sortpom</groupId>
         <artifactId>sortpom-maven-plugin</artifactId>

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+
+  <!--
+    Code might be used to include CRLF characters into log messages
+
+    Make sure that we sanitize everything that's being logged. Logging untrusted
+    data as is can produce misleading logs.
+  -->
+  <Match>
+    <Bug pattern="CRLF_INJECTION_LOGS" />
+  </Match>
+
+  <!--
+    Class does not implement a toString method
+
+    This can be useful for debugging, but it's probably not worth the trouble to
+    implement it for every class.
+  -->
+  <Match>
+    <Bug pattern="IMC_IMMATURE_CLASS_NO_TOSTRING" />
+  </Match>
+
+  <!--
+    Class has a circular dependency with other classes
+
+    StashBuildTrigger runs StashRepository, but StashRepository gets settings
+    from StashBuildTrigger. It should be possible to separate configuration from
+    the trigger. However, that it not a major issue.
+  -->
+  <Match>
+    <Bug pattern="FCCD_FIND_CLASS_CIRCULAR_DEPENDENCY" />
+    <Class name="stashpullrequestbuilder.stashpullrequestbuilder.StashBuildTrigger" />
+  </Match>
+
+  <!--
+    Code appears to call the same method on the same object redundantly
+
+    The detected issue is a false positive (a function getting current time when
+    it starts and when it finishes), but it's a sign that the logger should deal
+    with timestamps on its own, one timestamp for every line.
+  -->
+  <Match>
+    <Bug pattern="PRMC_POSSIBLY_REDUNDANT_METHOD_CALLS" />
+    <Class name="stashpullrequestbuilder.stashpullrequestbuilder.StashRepository" />
+  </Match>
+
+  <!--
+    Concatenating user-controlled input into a URL
+
+    Configurations strings such as the repository name should be validated at
+    the runtime. They should also be validated in the web interface. Strings
+    coming from the Bitbucket Server should also be checked before they are used
+    to construct a URL.
+  -->
+  <Match>
+    <Bug pattern="HTTP_PARAMETER_POLLUTION" />
+    <Class name="stashpullrequestbuilder.stashpullrequestbuilder.stash.StashApiClient" />
+  </Match>
+
+  <!--
+    Code does not presize the allocation of a collection
+
+    It's a false positive, but we should check if ArrayList is always the best
+    choice for the data that comes from the Bitbucket Server.
+  -->
+  <Match>
+    <Bug pattern="PSC_PRESIZE_COLLECTIONS" />
+    <Class name="stashpullrequestbuilder.stashpullrequestbuilder.stash.StashApiClient" />
+  </Match>
+
+  <!--
+    Code throws exception with static message string
+
+    We should provide whatever information is available about the context. That
+    should include the URL if the code is making an HTTP request.
+  -->
+  <Match>
+    <Bug pattern="WEM_WEAK_EXCEPTION_MESSAGING" />
+    <Class name="stashpullrequestbuilder.stashpullrequestbuilder.stash.StashApiClient" />
+  </Match>
+
+</FindBugsFilter>


### PR DESCRIPTION
```
*  Enable more SpotBugs checks, ignore known issues
   
   Set SpotBugs threshold to Low. Use fb-contrib and find-sec-bugs plugins
   for SpotBugs.
   
   Add src/spotbugs/excludesFilter.xml file to ignore known issues. The
   parent POM makes SpotBugs use that file if it exists.
   
   It is better to check for more issues and ignore known issues than to
   risk adding new issues unknowingly.
```

I knew that I could set the threshold to Low or to enable plugins, but not both. Some of the Low issues detected by plugins are hard to fix. Then I realized that there is nothing wrong in having an exclusion file.

The plugin POM makes it easy. The exclusion file is found automatically if it's called `src/spotbugs/excludesFilter.xml`. We can remove that file one day, and we won't have to change `pom.xml`.

Many of the ignored issues are easy to fix, but that's not the point of this PR. It will be done separately. In fact, #137 will fix `SIC_INNER_SHOULD_BE_STATIC_ANON`, the only remaining non-plugin Low warning in the code.

In some cases, we can decide to ignore a specific rule (in particular, I don't think that all "mature" classes should implement `toString()`). Then we can add the rationale for the exclusion file as a comment.

The message about the missing `compare` class is bogus and appears to be similar to https://github.com/spotbugs/spotbugs/issues/527 (however, no lambdas are used in our `StashPullRequestComment#compare()` implementation). In any case, it doesn't affect the test result.