### PR TITLE
Avoid Bitbucket autolinking to PRs from build numbers

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -55,7 +55,7 @@ public class StashRepository {
       "\\[\\*BuildFinished\\* \\*\\*%s\\*\\*\\] ([0-9a-fA-F]+) into ([0-9a-fA-F]+)";
 
   private static final String BUILD_FINISH_SENTENCE =
-      BUILD_FINISH_MARKER + " %n%n **[%s](%s)** - Build *#%d* which took *%s*";
+      BUILD_FINISH_MARKER + " %n%n **[%s](%s)** - Build *%d* which took *%s*";
 
   private static final String BUILD_SUCCESS_COMMENT = "✓ BUILD SUCCESS";
   private static final String BUILD_FAILURE_COMMENT = "✕ BUILD FAILURE";

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -55,7 +55,7 @@ public class StashRepository {
       "\\[\\*BuildFinished\\* \\*\\*%s\\*\\*\\] ([0-9a-fA-F]+) into ([0-9a-fA-F]+)";
 
   private static final String BUILD_FINISH_SENTENCE =
-      BUILD_FINISH_MARKER + " %n%n **[%s](%s)** - Build *%d* which took *%s*";
+      BUILD_FINISH_MARKER + " %n%n **[%s](%s)** - Build *&#x0023;%d* which took *%s*";
 
   private static final String BUILD_SUCCESS_COMMENT = "✓ BUILD SUCCESS";
   private static final String BUILD_FAILURE_COMMENT = "✕ BUILD FAILURE";


### PR DESCRIPTION
The existing comment format, e.g.

```
✕ BUILD FAILURE - Build #1065 which took 16 min
```

automatically creates a link from the text `#1065` to `/projects/{project}/repos/{repo}/pull-requests/1065` if it exists. This can cause confusion for developers and reviewers.

This change drops the `#` from the build number in comments, so that
BitBucket/Stash will no longer interpret it as a reference to a pull request.

The above example comment would change to the following:

```
✕ BUILD FAILURE - Build 1065 which took 16 min
```
