### PR TITLE
pom:xml: Update parent POM to version 3.54

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.48</version>
+    <version>3.54</version>
   </parent>
 
   <artifactId>stash-pullrequest-builder</artifactId>
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>${slf4jVersion}</version>
+      <version>1.7.25</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -91,9 +91,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
-      <version>2.1</version>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>jenkins-test-harness</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
```
*  pom:xml: Update parent POM to version 3.54
   
   Let jenkins-test-harness define the version of hamcrest.
   
   Don't use slf4jVersion, as the definition in the parent POM 3.54 is
   conditional and breaks at the flatten:flatten goal.
```