### PR TITLE
extensions.xml: Update git-changelist-maven-extension to version 1.1

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.0-beta-7</version>
+    <version>1.1</version>
   </extension>
 </extensions>


### PR DESCRIPTION
Why use beta if we can use a newer release? The only code change is https://github.com/jenkinsci/incrementals-tools/pull/14 (Make changelist.format configurable), all other changes are in the documentation.