### PR TITLE
StashApiClient: Don't ever return null from entityAsString()

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
@@ -4,6 +4,7 @@ import static java.lang.String.format;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import hudson.Util;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.security.KeyManagementException;
@@ -226,12 +227,13 @@ public class StashApiClient {
     }
 
     try {
-      return EntityUtils.toString(entity, Consts.UTF_8);
+      return Util.fixNull(EntityUtils.toString(entity, Consts.UTF_8));
     } catch (IOException e) {
       throw new StashApiException("Cannot decode HTTP response contents", e);
     }
   }
 
+  @Nonnull
   private String getRequest(String path) throws StashApiException {
     logger.log(Level.FINEST, "PR-GET-REQUEST:" + path);
     CloseableHttpClient client = getHttpClient();
@@ -353,6 +355,7 @@ public class StashApiClient {
     logger.log(Level.FINE, "Delete comment {" + path + "} returned result code; " + response);
   }
 
+  @Nonnull
   private String postRequest(String path, String comment) throws StashApiException {
     logger.log(Level.FINEST, "PR-POST-REQUEST:" + path + " with: " + comment);
     CloseableHttpClient client = getHttpClient();


### PR DESCRIPTION
```
*  StashApiClient: Don't ever return null from entityAsString()
   
   EntityUtils.toString() can return null under some obscure circumstances.
   From our point of view, it's the same as an empty response, as long as no
   exception is thrown. JSON parser would consider both as invalid JSON, but
   it's safer not to deal with null.
   
   Use Util.fix to convert null to an empty string.
   
   Mark getRequest() and postRequest() as @Nonnull, they return the result
   of entityAsString().
```
Found by sb-contrib (AI_ANNOTATION_ISSUES_NEEDS_NULLABLE).