### PR TITLE
StashApiClient: Remove wrappers around mapper.readValue()

### DIFF
--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClientTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClientTest.java
@@ -114,17 +114,6 @@ public class StashApiClientTest {
   }
 
   @Test
-  public void testParsePullRequestMergeStatus() throws Exception {
-    StashPullRequestMergeableResponse resp =
-        StashApiClient.parsePullRequestMergeStatus(
-            "{\"canMerge\":false,\"conflicted\":false,\"vetoes\":[{\"summaryMessage\":\"You may not merge after 6pm on a Friday.\",\"detailedMessage\":\"It is likely that your Blood Alcohol Content (BAC) exceeds the threshold for making sensible decisions regarding pull requests. Please try again on Monday.\"}]}");
-    assertThat(resp, is(notNullValue()));
-    assertThat(resp.getCanMerge(), is(false));
-    assertThat(resp.getConflicted(), is(false));
-    assertThat(resp.getVetoes(), hasSize(1));
-  }
-
-  @Test
   public void getPullRequests_gets_empty_list() throws Exception {
     stubFor(get(pullRequestPath(0)).willReturn(jsonResponse("PullRequestListEmpty.json")));
 

--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestMergeableResponseTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashPullRequestMergeableResponseTest.java
@@ -1,0 +1,26 @@
+package stashpullrequestbuilder.stashpullrequestbuilder.stash;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+public class StashPullRequestMergeableResponseTest {
+
+  @Test
+  public void testParsePullRequestMergeStatus() throws Exception {
+    ObjectMapper mapper = new ObjectMapper();
+
+    StashPullRequestMergeableResponse resp =
+        mapper.readValue(
+            "{\"canMerge\":false,\"conflicted\":false,\"vetoes\":[{\"summaryMessage\":\"Not approved\",\"detailedMessage\":\"Needs 2 approvals\"}]}",
+            StashPullRequestMergeableResponse.class);
+    assertThat(resp, is(notNullValue()));
+    assertThat(resp.getCanMerge(), is(false));
+    assertThat(resp.getConflicted(), is(false));
+    assertThat(resp.getVetoes(), hasSize(1));
+  }
+}


### PR DESCRIPTION
```
*  StashApiClient: Remove wrappers around mapper.readValue()
   
   Calling mapper.readValue() directly make the code more readable.
   
   Move a test for parsing StashPullRequestMergeableResponse to a new class,
   StashPullRequestMergeableResponseTest.
```
