### PR TITLE
StashApiClient: Process comments in getPullRequestComments() as they arrive

### DIFF
--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -59,17 +59,6 @@
   </Match>
 
   <!--
-    Code does not presize the allocation of a collection
-
-    It's a false positive, but we should check if ArrayList is always the best
-    choice for the data that comes from the Bitbucket Server.
-  -->
-  <Match>
-    <Bug pattern="PSC_PRESIZE_COLLECTIONS" />
-    <Class name="stashpullrequestbuilder.stashpullrequestbuilder.stash.StashApiClient" />
-  </Match>
-
-  <!--
     Code throws exception with static message string
 
     We should provide whatever information is available about the context. That

--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClientTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClientTest.java
@@ -224,7 +224,7 @@ public class StashApiClientTest {
   }
 
   @Test
-  public void getPullRequestComments_gets_pull_requests_from_multiple_pages() throws Exception {
+  public void getPullRequestComments_gets_comments_from_multiple_pages() throws Exception {
     stubFor(
         get(pullRequestActivitiesPath(0))
             .willReturn(jsonResponse("PullRequestCommentsPage1.json")));


### PR DESCRIPTION
```
*  StashApiClient: Process comments in getPullRequestComments() as they arrive
   
   Improve variable names and formatting for readability.
   
   No need to create a temporary list of StashPullRequestActivityResponse
   objects and extract comments at the end.
```

`getPullRequestComments()` has good test coverage already.