### PR TITLE
StashApiClient: Use Optional.of() in mergePullRequest()

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/stash/StashApiClient.java
@@ -183,7 +183,7 @@ public class StashApiClient {
     }
 
     // Return the whole response for the purpose of logging
-    return Optional.ofNullable(response);
+    return Optional.of(response);
   }
 
   private CloseableHttpClient getHttpClient() throws StashApiException {


### PR DESCRIPTION
```
*  StashApiClient: Use Optional.of() in mergePullRequest()
   
   Optional.ofNullable() can produce Optional.empty(), which would
   incorrectly indicate a successful merge.
   
   The argument of Optional.of() is guaranteed to be non-null now.
```
A little fix-up on top of the recent merge change (#152) found by IntelliJ IDEA.