### PR TITLE
StashRepository: Format timestamps using DateTimeFormatter

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -87,10 +87,6 @@ public class StashRepository {
     this.pollLog = pollLog;
   }
 
-  private static String logTimestamp() {
-    return ZonedDateTime.now().format(TIMESTAMP_FORMATTER);
-  }
-
   public Collection<StashPullRequestResponseValue> getTargetPullRequests() {
     List<StashPullRequestResponseValue> targetPullRequests = new ArrayList<>();
 
@@ -700,14 +696,14 @@ public class StashRepository {
   public void pollRepository() {
     long pollStartTime = System.currentTimeMillis();
     pollLog.resetLog();
-    pollLog.log("{}: poll started", logTimestamp());
+    pollLog.log("{}: poll started", ZonedDateTime.now().format(TIMESTAMP_FORMATTER));
 
     Collection<StashPullRequestResponseValue> targetPullRequests = getTargetPullRequests();
     addFutureBuildTasks(targetPullRequests);
 
     pollLog.log(
         "{}: poll completed in {}",
-        logTimestamp(),
+        ZonedDateTime.now().format(TIMESTAMP_FORMATTER),
         Util.getTimeSpanString(System.currentTimeMillis() - pollStartTime));
   }
 }

--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashRepository.java
@@ -16,7 +16,8 @@ import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.StringParameterValue;
 import java.lang.invoke.MethodHandles;
-import java.text.SimpleDateFormat;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -67,6 +68,9 @@ public class StashRepository {
   private static final Pattern ADDITIONAL_PARAMETER_REGEX_PATTERN =
       Pattern.compile(ADDITIONAL_PARAMETER_REGEX);
 
+  private static final DateTimeFormatter TIMESTAMP_FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss z");
+
   private Job<?, ?> job;
   private StashBuildTrigger trigger;
   private StashApiClient client;
@@ -84,7 +88,7 @@ public class StashRepository {
   }
 
   private static String logTimestamp() {
-    return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z").format(new java.util.Date());
+    return ZonedDateTime.now().format(TIMESTAMP_FORMATTER);
   }
 
   public Collection<StashPullRequestResponseValue> getTargetPullRequests() {

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -34,18 +34,6 @@
   </Match>
 
   <!--
-    Code appears to call the same method on the same object redundantly
-
-    The detected issue is a false positive (a function getting current time when
-    it starts and when it finishes), but it's a sign that the logger should deal
-    with timestamps on its own, one timestamp for every line.
-  -->
-  <Match>
-    <Bug pattern="PRMC_POSSIBLY_REDUNDANT_METHOD_CALLS" />
-    <Class name="stashpullrequestbuilder.stashpullrequestbuilder.StashRepository" />
-  </Match>
-
-  <!--
     Concatenating user-controlled input into a URL
 
     Configurations strings such as the repository name should be validated at


### PR DESCRIPTION
```
*  StashRepository: Format timestamps using DateTimeFormatter
   
   DateTimeFormatter appeared in Java 8. The formatter is thread-safe, so it
   can be initialized once.

*  StashRepository: Remove PRMC_POSSIBLY_REDUNDANT_METHOD_CALLS suppression
   
   SpotBugs assumes incorrectly that logTimestamp() would always return the
   same value. However, it doesn't consider multiple ZonedDateTime.now()
   calls as "redundant".
   
   While it might be possible to pass ZonedDateTime.now() as an argument to
   logTimestamp(), that method would become too simple to be useful.
   
   Replace calls to logTimestamp() with direct formatting calls.
```

I tried moving timestamp support to `StashPollingAction`. Prepending the timestamp as plain text adds too much clutter to the log. I would rather use a different font and maybe put timestamps on separate lines. That would be bigger change, as the log representation in memory would have to change.

This PR moves us in the right direction by switching to a safer time API and by eliminating a warning suppression.