### PR TITLE
pom:xml: Update parent POM to version 3.53

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.48</version>
+    <version>3.53</version>
   </parent>
 
   <artifactId>stash-pullrequest-builder</artifactId>
@@ -62,6 +62,17 @@
     <spotbugs.threshold>Low</spotbugs.threshold>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.13-rc-1</version>
+        <scope>test</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -91,20 +102,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
-      <version>2.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13-rc-1</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
```
*  pom:xml: Update parent POM to version 3.53
   
   Remove direct dependencies on JUnit and Hamcrest. The parent POM depends
   on them through jenkins-test-harness already.
   
   Use dependencyManagement to require a newer version of JUnit without
   having a direct dependency.
```

Parent POM 3.48 depends on Hamcrest 1.3, which it too old for our needs.

Parent POM 3.53 depends on Hamcrest 2.1, which is good, but a direct dependency on JUnit brings in a conflicting dependency on Hamcrest 1.3. Using `dependencyManagement` avoids that problem, and I believe it's the right thing to do.

Parent POM 3.54 is the latest, but it has an issue that breaks the use of `slf4jVersion` (https://github.com/jenkinsci/plugin-pom/pull/262), so let's wait until some solution is found.