### PR TITLE
pom.xml: Update JUnit to version 4.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.13-rc-1</version>
+        <version>4.13</version>
         <scope>test</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
No need to use a release candidate when a newer release is available.