### PR TITLE
StashBuildTrigger: Fix null pointer exception for missing credentials

### DIFF
--- a/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTriggerTest.java
+++ b/src/test/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTriggerTest.java
@@ -3,11 +3,18 @@ package stashpullrequestbuilder.stashpullrequestbuilder;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import hudson.model.Descriptor.PropertyType;
 import hudson.model.FreeStyleProject;
+import hudson.util.FormValidation;
+import hudson.util.FormValidation.Kind;
+import hudson.util.Secret;
 import java.util.Arrays;
 import java.util.Collections;
 import javax.servlet.ServletContext;
@@ -30,6 +37,14 @@ import org.mockito.quality.Strictness;
 @RunWith(MockitoJUnitRunner.class)
 public class StashBuildTriggerTest {
 
+  static final String cron = "H/5 * * * *";
+  static final String stashHost = "https://localhost/";
+  static final String credentialsId = "credential-id";
+  static final String projectCode = "PROJ";
+  static final String repositoryName = "MyRepo";
+
+  static final StashBuildTrigger.DescriptorImpl descriptor = StashBuildTrigger.descriptor;
+
   @Rule public JenkinsRule jenkinsRule = new JenkinsRule();
   @Rule public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
 
@@ -50,7 +65,6 @@ public class StashBuildTriggerTest {
     JSONObject json = new JSONObject();
 
     StaplerRequest staplerRequest = makeStaplerRequest();
-    StashBuildTrigger.DescriptorImpl descriptor = new StashBuildTrigger.DescriptorImpl();
     descriptor.configure(staplerRequest, json);
 
     FreeStyleProject project = jenkinsRule.createFreeStyleProject();
@@ -66,7 +80,6 @@ public class StashBuildTriggerTest {
     json.put("enablePipelineSupport", "false");
 
     StaplerRequest staplerRequest = makeStaplerRequest();
-    StashBuildTrigger.DescriptorImpl descriptor = new StashBuildTrigger.DescriptorImpl();
     descriptor.configure(staplerRequest, json);
 
     FreeStyleProject project = jenkinsRule.createFreeStyleProject();
@@ -82,7 +95,6 @@ public class StashBuildTriggerTest {
     json.put("enablePipelineSupport", "true");
 
     StaplerRequest staplerRequest = makeStaplerRequest();
-    StashBuildTrigger.DescriptorImpl descriptor = new StashBuildTrigger.DescriptorImpl();
     descriptor.configure(staplerRequest, json);
 
     FreeStyleProject project = jenkinsRule.createFreeStyleProject();
@@ -94,8 +106,6 @@ public class StashBuildTriggerTest {
 
   @Test
   public void check_getters() throws Exception {
-    StashBuildTrigger.DescriptorImpl descriptor = StashBuildTrigger.descriptor;
-
     // Field names from config.jelly
     Iterable<String> properties =
         Arrays.asList(
@@ -118,9 +128,82 @@ public class StashBuildTriggerTest {
             "ciBuildPhrases");
 
     for (String property : properties) {
-      System.out.println(property);
       PropertyType propertyType = descriptor.getPropertyType(property);
       assertThat(propertyType, is(notNullValue()));
     }
+  }
+
+  @Test
+  public void constructor_sets_required_properties() throws Exception {
+    StashBuildTrigger stashBuildTrigger =
+        new StashBuildTrigger(cron, stashHost, credentialsId, projectCode, repositoryName);
+
+    assertThat(stashBuildTrigger.getCron(), is(cron));
+    assertThat(stashBuildTrigger.getStashHost(), is(stashHost));
+    assertThat(stashBuildTrigger.getCredentialsId(), is(credentialsId));
+    assertThat(stashBuildTrigger.getProjectCode(), is(projectCode));
+    assertThat(stashBuildTrigger.getRepositoryName(), is(repositoryName));
+  }
+
+  @Test
+  public void start_works_with_valid_credentials() throws Exception {
+    StandardUsernamePasswordCredentials credentials =
+        mock(StandardUsernamePasswordCredentials.class);
+
+    when(credentials.getId()).thenReturn(credentialsId);
+    when(credentials.getUsername()).thenReturn("Username");
+    when(credentials.getPassword()).thenReturn(Secret.fromString("Password"));
+
+    SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
+
+    StashBuildTrigger stashBuildTrigger =
+        new StashBuildTrigger(cron, stashHost, credentialsId, projectCode, repositoryName);
+
+    FreeStyleProject project = jenkinsRule.createFreeStyleProject();
+    stashBuildTrigger.start(project, true);
+
+    assertThat(stashBuildTrigger.getRepository(), is(notNullValue()));
+  }
+
+  @Test
+  public void start_fails_with_empty_credentialId() throws Exception {
+    StashBuildTrigger stashBuildTrigger =
+        new StashBuildTrigger(cron, stashHost, "", projectCode, repositoryName);
+
+    FreeStyleProject project = jenkinsRule.createFreeStyleProject();
+    stashBuildTrigger.start(project, true);
+
+    assertThat(stashBuildTrigger.getRepository(), is(nullValue()));
+  }
+
+  @Test
+  public void start_fails_with_unknown_credentialId() throws Exception {
+    StashBuildTrigger stashBuildTrigger =
+        new StashBuildTrigger(cron, stashHost, credentialsId, projectCode, repositoryName);
+
+    FreeStyleProject project = jenkinsRule.createFreeStyleProject();
+    stashBuildTrigger.start(project, true);
+
+    assertThat(stashBuildTrigger.getRepository(), is(nullValue()));
+  }
+
+  @Test
+  public void nonempty_credential_accepted() throws Exception {
+    FormValidation formValidation = descriptor.doCheckCredentialsId("credential-id");
+    assertThat(formValidation.kind, is(Kind.OK));
+    assertThat(formValidation.getMessage(), is(nullValue()));
+  }
+
+  @Test
+  public void empty_credential_rejected() throws Exception {
+    FormValidation formValidation = descriptor.doCheckCredentialsId("");
+    assertThat(formValidation.kind, is(Kind.ERROR));
+    assertThat(formValidation.getMessage(), is("Credentials cannot be empty"));
+  }
+
+  @Test
+  public void null_credential_rejected() throws Exception {
+    FormValidation formValidation = descriptor.doCheckCredentialsId(null);
+    assertThat(formValidation.getMessage(), is("Credentials cannot be empty"));
   }
 }


### PR DESCRIPTION
```
*  StashBuildTrigger: Fix null pointer exception for missing credentials
   
   If the credential ID is empty or if the credentials cannot be looked up
   by the credential ID, log the error to the polling log and don't start
   the trigger.
   
   Ensure that non-empty credentials are selected in the GUI.
   
   Remove public getUsername() and getPassword() methods, they are not used
   by other classes.
   
   Add more unit tests for StashBuildTrigger constructor, start() and the
   new functionality. Remove leftover debug print.
```
The code should validate all 5 mandatory parameters, the crontab, the server API URL, the credentials and the project/repository. The validations are different for different parameters. I decided to start with the credentials to avoid having too many changes at once.

I was able to add unit tests for StashBuildTrigger (not the descriptor). I'm glad I could find a way to add credentials in one line, that was hard to figure out! Many plugins use much longer code for the same effect.